### PR TITLE
feat(middleware): add csrf middleware for automatic csrf protection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require": {
     "php": "^8.4",
-    "tempest/framework": "^1.0"
+    "tempest/framework": "^1.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^12.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d556ffa82003502ad8f5419b857b79ea",
+    "content-hash": "228bed5976fec4a4f0b896a20fa452a0",
     "packages": [
         {
             "name": "composer/semver",

--- a/src/Middleware/SetCsrfCookie.php
+++ b/src/Middleware/SetCsrfCookie.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Middleware;
+
+use Override;
+use Tempest\Clock\Clock;
+use Tempest\Core\AppConfig;
+use Tempest\Core\Priority;
+use Tempest\Http\Cookie\Cookie;
+use Tempest\Http\Cookie\CookieManager;
+use Tempest\Http\Request;
+use Tempest\Http\Response;
+use Tempest\Http\Session\Session;
+use Tempest\Http\Session\SessionConfig;
+use Tempest\Router\HttpMiddleware;
+use Tempest\Router\HttpMiddlewareCallable;
+use Tempest\Support\Str;
+
+#[Priority(Priority::HIGH)]
+final readonly class SetCsrfCookie implements HttpMiddleware
+{
+    private const string COOKIE_NAME = 'XSRF-TOKEN';
+
+    public function __construct(
+        private Session $session,
+        private AppConfig $appConfig,
+        private SessionConfig $sessionConfig,
+        private CookieManager $cookies,
+        private Clock $clock,
+    ) {}
+
+    #[Override]
+    public function __invoke(Request $request, HttpMiddlewareCallable $next): Response
+    {
+        $token = $this->session->get(Session::CSRF_TOKEN_KEY) ?? '';
+
+        $this->cookies->add(new Cookie(
+            key: self::COOKIE_NAME,
+            value: $token,
+            expiresAt: $this->clock->now()->plus($this->sessionConfig->expiration),
+            path: '/',
+            secure: Str\starts_with($this->appConfig->baseUri, 'https'),
+        ));
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This commit introduces a new `SetCsrfCookie` middleware to provide seamless, out-of-the-box CSRF protection for Inertia forms.

### Problem
Tempest's CSRF protection works by validating an `xsrf-token` on incoming requests. While developers could use `<x-csrf-token />` in a standard view, this is not available in a JavaScript-driven Inertia component.

**Solution**
This new middleware leverages the automatic CSRF handling built into Axios, the HTTP client used by Inertia. Axios automatically looks for a cookie named `XSRF-TOKEN` and, if found, sends its value in on all subsequent requests.

The `SetCsrfCookie` middleware bridges this gap by:

1. Reading the CSRF token from Tempest's session.
2. Setting it in a non-HttpOnly cookie on every response.

### Benefit
By adding this single middleware to their global stack, users of the package will have CSRF protection work automatically for all Inertia form submissions (form.post, form.put, etc.) without needing to write any custom JavaScript or client-side configuration. This provides a more secure and seamless developer experience.