### PR TITLE
breaking: updates for Tempest 2.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,13 @@
   "require": {
     "php": "^8.4",
     "ext-json": "*",
-    "tempest/framework": "^1.5"
+    "tempest/framework": "^1.5|^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^12.3.0",
-    "rector/rector": "^2.1.2",
+    "phpunit/phpunit": "^12.3",
+    "rector/rector": "^2.1",
     "carthage-software/mago": "^0.26.1",
-    "mockery/mockery": "^1.6.12"
+    "mockery/mockery": "^1.6"
   },
   "suggest": {
     "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` tempest command."

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b78fed9f89ff32e65db380857439f737",
+    "content-hash": "bc22a3b83c397f7b499082cad218e6e9",
     "packages": [
         {
             "name": "composer/semver",
-            "version": "3.4.3",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
                 "shasum": ""
             },
             "require": {
@@ -69,7 +69,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.3"
+                "source": "https://github.com/composer/semver/tree/3.4.4"
             },
             "funding": [
                 {
@@ -79,13 +79,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T14:15:21+00:00"
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -164,33 +160,32 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.10",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc"
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5817d0659c5b50c9b950feb9af7b9668e2c436bc",
-                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11.0",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.3",
-                "phpunit/phpunit": "^8.5 || ^9.5",
-                "vimeo/psalm": "^4.25 || ^5.4"
+                "doctrine/coding-standard": "^12.0 || ^13.0",
+                "phpstan/phpstan": "^1.12 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.4 || ^2.0",
+                "phpstan/phpstan-strict-rules": "^1.6 || ^2.0",
+                "phpunit/phpunit": "^8.5 || ^12.2"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
+                    "Doctrine\\Inflector\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -235,7 +230,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.10"
+                "source": "https://github.com/doctrine/inflector/tree/2.1.0"
             },
             "funding": [
                 {
@@ -251,7 +246,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-18T20:23:39+00:00"
+            "time": "2025-08-10T19:31:58+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -399,16 +394,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.18.3",
+            "version": "2.18.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "59a123a3d459c5a23055802237cb317f609867e5"
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/59a123a3d459c5a23055802237cb317f609867e5",
-                "reference": "59a123a3d459c5a23055802237cb317f609867e5",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/d2102955e48b9fd9ab24280a7ad12ed552752c4d",
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d",
                 "shasum": ""
             },
             "require": {
@@ -458,7 +453,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.18.3"
+                "source": "https://github.com/filp/whoops/tree/2.18.4"
             },
             "funding": [
                 {
@@ -466,20 +461,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-06-16T00:02:10+00:00"
+            "time": "2025-08-08T12:00:00+00:00"
         },
         {
             "name": "giggsey/libphonenumber-for-php-lite",
-            "version": "9.0.10",
+            "version": "9.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php-lite.git",
-                "reference": "205492b2d54e3cc808110f1ba6e7c53a1b839196"
+                "reference": "af794cc2ed18edeebadf5ffe08eb6add04275709"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php-lite/zipball/205492b2d54e3cc808110f1ba6e7c53a1b839196",
-                "reference": "205492b2d54e3cc808110f1ba6e7c53a1b839196",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php-lite/zipball/af794cc2ed18edeebadf5ffe08eb6add04275709",
+                "reference": "af794cc2ed18edeebadf5ffe08eb6add04275709",
                 "shasum": ""
             },
             "require": {
@@ -492,7 +487,7 @@
             "require-dev": {
                 "ext-dom": "*",
                 "friendsofphp/php-cs-fixer": "^3.71",
-                "infection/infection": "^0.28.0",
+                "infection/infection": "^0.29|^0.31.0",
                 "nette/php-generator": "^4.1",
                 "php-coveralls/php-coveralls": "^2.7",
                 "phpstan/extension-installer": "^1.4.3",
@@ -544,7 +539,7 @@
                 "issues": "https://github.com/giggsey/libphonenumber-for-php-lite/issues",
                 "source": "https://github.com/giggsey/libphonenumber-for-php-lite"
             },
-            "time": "2025-07-18T06:46:03+00:00"
+            "time": "2025-09-16T07:09:25+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -610,22 +605,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.9.3",
+            "version": "7.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
-                "guzzlehttp/psr7": "^2.7.0",
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -716,7 +711,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
             },
             "funding": [
                 {
@@ -732,20 +727,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:37:11+00:00"
+            "time": "2025-08-23T22:36:01+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
-                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
                 "shasum": ""
             },
             "require": {
@@ -753,7 +748,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "type": "library",
             "extra": {
@@ -799,7 +794,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.2.0"
+                "source": "https://github.com/guzzle/promises/tree/2.3.0"
             },
             "funding": [
                 {
@@ -815,20 +810,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:27:01+00:00"
+            "time": "2025-08-22T14:34:08+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.1",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
+                "reference": "21dc724a0583619cd1652f673303492272778051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
+                "reference": "21dc724a0583619cd1652f673303492272778051",
                 "shasum": ""
             },
             "require": {
@@ -844,7 +839,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -915,7 +910,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
             },
             "funding": [
                 {
@@ -931,7 +926,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T12:30:47+00:00"
+            "time": "2025-08-23T21:21:41+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
@@ -1503,27 +1498,27 @@
         },
         {
             "name": "nette/php-generator",
-            "version": "v4.1.8",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/php-generator.git",
-                "reference": "42806049a7774a2bd316c958f5dcf01c6b5c56fa"
+                "reference": "4707546a1f11badd72f5d82af4f8a6bc64bd56ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/php-generator/zipball/42806049a7774a2bd316c958f5dcf01c6b5c56fa",
-                "reference": "42806049a7774a2bd316c958f5dcf01c6b5c56fa",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/4707546a1f11badd72f5d82af4f8a6bc64bd56ac",
+                "reference": "4707546a1f11badd72f5d82af4f8a6bc64bd56ac",
                 "shasum": ""
             },
             "require": {
-                "nette/utils": "^3.2.9 || ^4.0",
-                "php": "8.0 - 8.4"
+                "nette/utils": "^4.0.6",
+                "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "jetbrains/phpstorm-attributes": "dev-master",
+                "jetbrains/phpstorm-attributes": "^1.2",
                 "nette/tester": "^2.4",
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "phpstan/phpstan": "^1.0",
+                "nikic/php-parser": "^5.0",
+                "phpstan/phpstan-nette": "^2.0@stable",
                 "tracy/tracy": "^2.8"
             },
             "suggest": {
@@ -1532,10 +1527,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
                 "classmap": [
                     "src/"
                 ]
@@ -1556,7 +1554,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 8.4 features.",
+            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 8.5 features.",
             "homepage": "https://nette.org",
             "keywords": [
                 "code",
@@ -1566,9 +1564,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/php-generator/issues",
-                "source": "https://github.com/nette/php-generator/tree/v4.1.8"
+                "source": "https://github.com/nette/php-generator/tree/v4.2.0"
             },
-            "time": "2025-03-31T00:29:29+00:00"
+            "time": "2025-08-06T18:24:31+00:00"
         },
         {
             "name": "nette/schema",
@@ -1634,29 +1632,29 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.7",
+            "version": "v4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "e67c4061eb40b9c113b218214e42cb5a0dda28f2"
+                "reference": "c930ca4e3cf4f17dcfb03037703679d2396d2ede"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/e67c4061eb40b9c113b218214e42cb5a0dda28f2",
-                "reference": "e67c4061eb40b9c113b218214e42cb5a0dda28f2",
+                "url": "https://api.github.com/repos/nette/utils/zipball/c930ca4e3cf4f17dcfb03037703679d2396d2ede",
+                "reference": "c930ca4e3cf4f17dcfb03037703679d2396d2ede",
                 "shasum": ""
             },
             "require": {
-                "php": "8.0 - 8.4"
+                "php": "8.0 - 8.5"
             },
             "conflict": {
                 "nette/finder": "<3",
                 "nette/schema": "<1.2.2"
             },
             "require-dev": {
-                "jetbrains/phpstorm-attributes": "dev-master",
+                "jetbrains/phpstorm-attributes": "^1.2",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-nette": "^2.0@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
@@ -1674,6 +1672,9 @@
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
                 "classmap": [
                     "src/"
                 ]
@@ -1714,22 +1715,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.7"
+                "source": "https://github.com/nette/utils/tree/v4.0.8"
             },
-            "time": "2025-06-03T04:55:08+00:00"
+            "time": "2025-08-06T21:43:34+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.0",
+            "version": "v5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56"
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/221b0d0fdf1369c71047ad1d18bb5880017bbc56",
-                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
                 "shasum": ""
             },
             "require": {
@@ -1748,7 +1749,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -1772,22 +1773,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
             },
-            "time": "2025-07-27T20:03:57+00:00"
+            "time": "2025-08-13T20:13:15+00:00"
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.9.3",
+            "version": "1.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "e3fac8b24f56113f7cb96af14958c0dd16330f54"
+                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/e3fac8b24f56113f7cb96af14958c0dd16330f54",
-                "reference": "e3fac8b24f56113f7cb96af14958c0dd16330f54",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
+                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
                 "shasum": ""
             },
             "require": {
@@ -1795,7 +1796,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25 || ^10.5.53 || ^11.5.34"
             },
             "type": "library",
             "extra": {
@@ -1837,7 +1838,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.9.3"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.4"
             },
             "funding": [
                 {
@@ -1849,7 +1850,65 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-20T21:41:07+00:00"
+            "time": "2025-08-21T11:53:16+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "578fa296a166605d97b94091f724f1257185d278"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578fa296a166605d97b94091f724f1257185d278",
+                "reference": "578fa296a166605d97b94091f724f1257185d278",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-19T08:58:49+00:00"
         },
         {
             "name": "psr-discovery/discovery",
@@ -2530,6 +2589,66 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
+            "name": "rector/rector",
+            "version": "2.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "c34cc07c4698f007a20dc5c99ff820089ae413ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/c34cc07c4698f007a20dc5c99ff820089ae413ce",
+                "reference": "c34cc07c4698f007a20dc5c99ff820089ae413ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.18"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.1.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-10T11:13:58+00:00"
+        },
+        {
             "name": "symfony/cache",
             "version": "v7.3.2",
             "source": {
@@ -2776,16 +2895,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.3.0",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d"
+                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/497f73ac996a598c92409b44ac43b6690c4f666d",
-                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b7dc69e71de420ac04bc9ab830cf3ffebba48191",
+                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191",
                 "shasum": ""
             },
             "require": {
@@ -2836,7 +2955,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -2848,11 +2967,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-22T09:11:45+00:00"
+            "time": "2025-08-13T11:49:31+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -2932,16 +3055,16 @@
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "d43e84d9522345f96ad6283d5dfccc8c1cfc299b"
+                "reference": "a32f3f45f1990db8c4341d5122a7d3a381c7e575"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/d43e84d9522345f96ad6283d5dfccc8c1cfc299b",
-                "reference": "d43e84d9522345f96ad6283d5dfccc8c1cfc299b",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/a32f3f45f1990db8c4341d5122a7d3a381c7e575",
+                "reference": "a32f3f45f1990db8c4341d5122a7d3a381c7e575",
                 "shasum": ""
             },
             "require": {
@@ -2992,7 +3115,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.3.2"
+                "source": "https://github.com/symfony/mailer/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -3012,7 +3135,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:36:08+00:00"
+            "time": "2025-08-13T11:49:31+00:00"
         },
         {
             "name": "symfony/mime",
@@ -3104,7 +3227,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -3163,7 +3286,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -3175,6 +3298,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -3183,7 +3310,7 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -3246,7 +3373,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -3258,6 +3385,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -3266,7 +3397,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -3327,7 +3458,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -3339,6 +3470,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -3347,7 +3482,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -3408,7 +3543,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -3420,6 +3555,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -3428,7 +3567,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -3488,7 +3627,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -3500,6 +3639,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -3508,7 +3651,7 @@
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
@@ -3567,7 +3710,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -3579,6 +3722,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -3587,16 +3734,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.3.0",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af"
+                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
-                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
+                "url": "https://api.github.com/repos/symfony/process/zipball/32241012d521e2e8a9d713adb0812bb773b907f1",
+                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1",
                 "shasum": ""
             },
             "require": {
@@ -3628,7 +3775,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.3.0"
+                "source": "https://github.com/symfony/process/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -3640,11 +3787,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-17T09:11:12+00:00"
+            "time": "2025-08-18T09:42:54+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3805,16 +3956,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "53205bea27450dc5c65377518b3275e126d45e75"
+                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/53205bea27450dc5c65377518b3275e126d45e75",
-                "reference": "53205bea27450dc5c65377518b3275e126d45e75",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
+                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
                 "shasum": ""
             },
             "require": {
@@ -3868,7 +4019,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.2"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -3888,20 +4039,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-29T20:02:46+00:00"
+            "time": "2025-08-13T11:49:31+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "05b3e90654c097817325d6abd284f7938b05f467"
+                "reference": "d4dfcd2a822cbedd7612eb6fbd260e46f87b7137"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/05b3e90654c097817325d6abd284f7938b05f467",
-                "reference": "05b3e90654c097817325d6abd284f7938b05f467",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/d4dfcd2a822cbedd7612eb6fbd260e46f87b7137",
+                "reference": "d4dfcd2a822cbedd7612eb6fbd260e46f87b7137",
                 "shasum": ""
             },
             "require": {
@@ -3949,7 +4100,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.3.2"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -3969,20 +4120,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:47:49+00:00"
+            "time": "2025-08-18T13:10:53+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "b8d7d868da9eb0919e99c8830431ea087d6aae30"
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/b8d7d868da9eb0919e99c8830431ea087d6aae30",
-                "reference": "b8d7d868da9eb0919e99c8830431ea087d6aae30",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
                 "shasum": ""
             },
             "require": {
@@ -4025,7 +4176,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.3.2"
+                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -4045,20 +4196,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:47:49+00:00"
+            "time": "2025-08-27T11:34:33+00:00"
         },
         {
             "name": "tempest/framework",
-            "version": "v1.5.1",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tempestphp/tempest-framework.git",
-                "reference": "3038fb461f89124acd7a7276d60ee9c1ce938c0f"
+                "reference": "8b4208b2106ce084a446ff4f77dfd141a1095867"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tempestphp/tempest-framework/zipball/3038fb461f89124acd7a7276d60ee9c1ce938c0f",
-                "reference": "3038fb461f89124acd7a7276d60ee9c1ce938c0f",
+                "url": "https://api.github.com/repos/tempestphp/tempest-framework/zipball/8b4208b2106ce084a446ff4f77dfd141a1095867",
+                "reference": "8b4208b2106ce084a446ff4f77dfd141a1095867",
                 "shasum": ""
             },
             "require": {
@@ -4078,6 +4229,7 @@
                 "laminas/laminas-diactoros": "^3.3",
                 "league/commonmark": "^2.7",
                 "league/flysystem": "^3.29.1",
+                "league/mime-type-detection": "^1.16",
                 "monolog/monolog": "^3.7.0",
                 "nette/php-generator": "^4.1.6",
                 "nikic/php-parser": "^5.3",
@@ -4090,15 +4242,16 @@
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0|^2.0",
                 "psr/log": "^3.0.0",
-                "symfony/cache": "^7.2",
+                "rector/rector": "^2.1",
+                "symfony/cache": "^7.3",
                 "symfony/mailer": "^7.2.6",
-                "symfony/process": "^7.1",
+                "symfony/process": "^7.3",
                 "symfony/uid": "^7.1",
                 "symfony/var-dumper": "^7.1",
                 "symfony/var-exporter": "^7.1",
                 "symfony/yaml": "^7.3",
                 "tempest/highlight": "^2.11.4",
-                "vlucas/phpdotenv": "^5.6",
+                "vlucas/phpdotenv": "^5.6.1",
                 "voku/portable-ascii": "^2.0.3"
             },
             "replace": {
@@ -4109,6 +4262,7 @@
                 "tempest/console": "self.version",
                 "tempest/container": "self.version",
                 "tempest/core": "self.version",
+                "tempest/cryptography": "self.version",
                 "tempest/database": "self.version",
                 "tempest/datetime": "self.version",
                 "tempest/debug": "self.version",
@@ -4123,27 +4277,29 @@
                 "tempest/log": "self.version",
                 "tempest/mail": "self.version",
                 "tempest/mapper": "self.version",
+                "tempest/process": "self.version",
                 "tempest/reflection": "self.version",
                 "tempest/router": "self.version",
                 "tempest/storage": "self.version",
                 "tempest/support": "self.version",
+                "tempest/upgrade": "self.version",
                 "tempest/validation": "self.version",
                 "tempest/view": "self.version",
                 "tempest/vite": "self.version"
             },
             "require-dev": {
+                "aws/aws-sdk-php": "^3.338.0",
                 "azure-oss/storage-blob-flysystem": "^1.2",
-                "carthage-software/mago": "0.26.1",
+                "carthage-software/mago": "^1.0.0-beta.16",
                 "guzzlehttp/psr7": "^2.6.1",
-                "league/flysystem-aws-s3-v3": "^3.0",
-                "league/flysystem-azure-blob-storage": "^3.0",
-                "league/flysystem-ftp": "^3.0",
-                "league/flysystem-google-cloud-storage": "^3.0",
+                "league/flysystem-aws-s3-v3": "^3.25.1",
+                "league/flysystem-ftp": "^3.25.1",
+                "league/flysystem-google-cloud-storage": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
-                "league/flysystem-memory": "^3.0",
-                "league/flysystem-read-only": "^3.0",
-                "league/flysystem-sftp-v3": "^3.0",
-                "league/flysystem-ziparchive": "^3.0",
+                "league/flysystem-memory": "^3.25.1",
+                "league/flysystem-read-only": "^3.25.1",
+                "league/flysystem-sftp-v3": "^3.25.1",
+                "league/flysystem-ziparchive": "^3.25.1",
                 "masterminds/html5": "^2.9",
                 "microsoft/azure-storage-blob": "^1.5",
                 "mikey179/vfsstream": "^2.0@dev",
@@ -4154,13 +4310,12 @@
                 "phpstan/phpstan": "^2.0",
                 "phpunit/phpunit": "^12.2.3",
                 "predis/predis": "^3.0.0",
-                "rector/rector": "^2.0-rc2",
                 "spatie/phpunit-snapshot-assertions": "^5.1.8",
                 "spaze/phpstan-disallowed-calls": "^4.0",
                 "symfony/amazon-mailer": "^7.2.0",
                 "symfony/postmark-mailer": "^7.2.6",
                 "symplify/monorepo-builder": "^11.2",
-                "tempest/blade": "^0.1.0",
+                "tempest/blade": "dev-main",
                 "twig/twig": "^3.16"
             },
             "suggest": {
@@ -4222,8 +4377,10 @@
                     "Tempest\\Mapper\\": "packages/mapper/src",
                     "Tempest\\Router\\": "packages/router/src",
                     "Tempest\\Console\\": "packages/console/src",
+                    "Tempest\\Process\\": "packages/process/src",
                     "Tempest\\Storage\\": "packages/storage/src",
                     "Tempest\\Support\\": "packages/support/src",
+                    "Tempest\\Upgrade\\": "packages/upgrade/src",
                     "Tempest\\Database\\": "packages/database/src",
                     "Tempest\\DateTime\\": "packages/datetime/src",
                     "Tempest\\EventBus\\": "packages/event-bus/src",
@@ -4235,7 +4392,8 @@
                     "Tempest\\Generation\\": "packages/generation/src",
                     "Tempest\\HttpClient\\": "packages/http-client/src",
                     "Tempest\\Reflection\\": "packages/reflection/src",
-                    "Tempest\\Validation\\": "packages/validation/src"
+                    "Tempest\\Validation\\": "packages/validation/src",
+                    "Tempest\\Cryptography\\": "packages/cryptography/src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4245,7 +4403,7 @@
             "description": "The PHP framework that gets out of your way.",
             "support": {
                 "issues": "https://github.com/tempestphp/tempest-framework/issues",
-                "source": "https://github.com/tempestphp/tempest-framework/tree/v1.5.1"
+                "source": "https://github.com/tempestphp/tempest-framework/tree/v2.0.3"
             },
             "funding": [
                 {
@@ -4253,7 +4411,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-29T07:56:38+00:00"
+            "time": "2025-09-19T09:26:42+00:00"
         },
         {
             "name": "tempest/highlight",
@@ -4845,93 +5003,35 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpstan/phpstan",
-            "version": "2.1.21",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "1ccf445757458c06a04eb3f803603cb118fe5fa6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1ccf445757458c06a04eb3f803603cb118fe5fa6",
-                "reference": "1ccf445757458c06a04eb3f803603cb118fe5fa6",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4|^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan-shim": "*"
-            },
-            "bin": [
-                "phpstan",
-                "phpstan.phar"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPStan - PHP Static Analysis Tool",
-            "keywords": [
-                "dev",
-                "static analysis"
-            ],
-            "support": {
-                "docs": "https://phpstan.org/user-guide/getting-started",
-                "forum": "https://github.com/phpstan/phpstan/discussions",
-                "issues": "https://github.com/phpstan/phpstan/issues",
-                "security": "https://github.com/phpstan/phpstan/security/policy",
-                "source": "https://github.com/phpstan/phpstan-src"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/ondrejmirtes",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/phpstan",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-07-28T19:35:08+00:00"
-        },
-        {
             "name": "phpunit/php-code-coverage",
-            "version": "12.3.2",
+            "version": "12.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "086553c5b2e0e1e20293d782d788ab768202b621"
+                "reference": "99e692c6a84708211f7536ba322bbbaef57ac7fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/086553c5b2e0e1e20293d782d788ab768202b621",
-                "reference": "086553c5b2e0e1e20293d782d788ab768202b621",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/99e692c6a84708211f7536ba322bbbaef57ac7fc",
+                "reference": "99e692c6a84708211f7536ba322bbbaef57ac7fc",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.4.0",
+                "nikic/php-parser": "^5.6.1",
                 "php": ">=8.3",
                 "phpunit/php-file-iterator": "^6.0",
                 "phpunit/php-text-template": "^5.0",
                 "sebastian/complexity": "^5.0",
-                "sebastian/environment": "^8.0",
+                "sebastian/environment": "^8.0.3",
                 "sebastian/lines-of-code": "^4.0",
                 "sebastian/version": "^6.0",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.1"
+                "phpunit/phpunit": "^12.3.7"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -4969,7 +5069,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.3.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.3.8"
             },
             "funding": [
                 {
@@ -4989,7 +5089,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-29T06:19:24+00:00"
+            "time": "2025-09-17T11:31:43+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -5238,16 +5338,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.3.0",
+            "version": "12.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "264da860d6fe0d00582355a6ecbbf7ae57b44895"
+                "reference": "6a62f2b394e042884e4997ddc8b8db1ce56a0009"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/264da860d6fe0d00582355a6ecbbf7ae57b44895",
-                "reference": "264da860d6fe0d00582355a6ecbbf7ae57b44895",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6a62f2b394e042884e4997ddc8b8db1ce56a0009",
+                "reference": "6a62f2b394e042884e4997ddc8b8db1ce56a0009",
                 "shasum": ""
             },
             "require": {
@@ -5257,23 +5357,23 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.3",
+                "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.3.2",
+                "phpunit/php-code-coverage": "^12.3.7",
                 "phpunit/php-file-iterator": "^6.0.0",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
-                "sebastian/cli-parser": "^4.0.0",
-                "sebastian/comparator": "^7.1.0",
+                "sebastian/cli-parser": "^4.1.0",
+                "sebastian/comparator": "^7.1.3",
                 "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.0.2",
+                "sebastian/environment": "^8.0.3",
                 "sebastian/exporter": "^7.0.0",
-                "sebastian/global-state": "^8.0.0",
+                "sebastian/global-state": "^8.0.2",
                 "sebastian/object-enumerator": "^7.0.0",
-                "sebastian/type": "^6.0.2",
+                "sebastian/type": "^6.0.3",
                 "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
             },
@@ -5315,7 +5415,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.3.0"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.3.11"
             },
             "funding": [
                 {
@@ -5339,80 +5439,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-01T05:14:47+00:00"
-        },
-        {
-            "name": "rector/rector",
-            "version": "2.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/rectorphp/rector.git",
-                "reference": "40a71441dd73fa150a66102f5ca1364c44fc8fff"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40a71441dd73fa150a66102f5ca1364c44fc8fff",
-                "reference": "40a71441dd73fa150a66102f5ca1364c44fc8fff",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.18"
-            },
-            "conflict": {
-                "rector/rector-doctrine": "*",
-                "rector/rector-downgrade-php": "*",
-                "rector/rector-phpunit": "*",
-                "rector/rector-symfony": "*"
-            },
-            "suggest": {
-                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
-            },
-            "bin": [
-                "bin/rector"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
-            "homepage": "https://getrector.com/",
-            "keywords": [
-                "automation",
-                "dev",
-                "migration",
-                "refactoring"
-            ],
-            "support": {
-                "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.1.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/tomasvotruba",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-07-17T19:30:06+00:00"
+            "time": "2025-09-14T06:21:44+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "4.0.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "6d584c727d9114bcdc14c86711cd1cad51778e7c"
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/6d584c727d9114bcdc14c86711cd1cad51778e7c",
-                "reference": "6d584c727d9114bcdc14c86711cd1cad51778e7c",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
                 "shasum": ""
             },
             "require": {
@@ -5424,7 +5464,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "4.2-dev"
                 }
             },
             "autoload": {
@@ -5448,28 +5488,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:53:50+00:00"
+            "time": "2025-09-14T09:36:45+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.0",
+            "version": "7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "03d905327dccc0851c9a08d6a979dfc683826b6f"
+                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/03d905327dccc0851c9a08d6a979dfc683826b6f",
-                "reference": "03d905327dccc0851c9a08d6a979dfc683826b6f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dc904b4bb3ab070865fa4068cd84f3da8b945148",
+                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148",
                 "shasum": ""
             },
             "require": {
@@ -5528,7 +5580,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.0"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.3"
             },
             "funding": [
                 {
@@ -5548,7 +5600,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-17T07:41:58+00:00"
+            "time": "2025-08-20T11:27:00+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -5677,16 +5729,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.0.2",
+            "version": "8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "d364b9e5d0d3b18a2573351a1786fbf96b7e0792"
+                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d364b9e5d0d3b18a2573351a1786fbf96b7e0792",
-                "reference": "d364b9e5d0d3b18a2573351a1786fbf96b7e0792",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
                 "shasum": ""
             },
             "require": {
@@ -5729,7 +5781,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.2"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
             },
             "funding": [
                 {
@@ -5749,7 +5801,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T15:05:44+00:00"
+            "time": "2025-08-12T14:11:56+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -5831,16 +5883,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "8.0.0",
+            "version": "8.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "570a2aeb26d40f057af686d63c4e99b075fb6cbc"
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/570a2aeb26d40f057af686d63c4e99b075fb6cbc",
-                "reference": "570a2aeb26d40f057af686d63c4e99b075fb6cbc",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
                 "shasum": ""
             },
             "require": {
@@ -5881,15 +5933,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.0"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:56:59+00:00"
+            "time": "2025-08-29T11:29:25+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -6065,16 +6129,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "c405ae3a63e01b32eb71577f8ec1604e39858a7c"
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/c405ae3a63e01b32eb71577f8ec1604e39858a7c",
-                "reference": "c405ae3a63e01b32eb71577f8ec1604e39858a7c",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
                 "shasum": ""
             },
             "require": {
@@ -6117,28 +6181,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T05:00:01+00:00"
+            "time": "2025-08-13T04:44:59+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "6.0.2",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "1d7cd6e514384c36d7a390347f57c385d4be6069"
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/1d7cd6e514384c36d7a390347f57c385d4be6069",
-                "reference": "1d7cd6e514384c36d7a390347f57c385d4be6069",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
                 "shasum": ""
             },
             "require": {
@@ -6174,15 +6250,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-03-18T13:37:31+00:00"
+            "time": "2025-08-09T06:57:12+00:00"
         },
         {
             "name": "sebastian/version",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc22a3b83c397f7b499082cad218e6e9",
+    "content-hash": "e014cda26d911175052cc3269e8bfd53",
     "packages": [
         {
             "name": "composer/semver",
@@ -5338,16 +5338,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.3.11",
+            "version": "12.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6a62f2b394e042884e4997ddc8b8db1ce56a0009"
+                "reference": "729861f66944204f5b446ee1cb156f02f2a439a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6a62f2b394e042884e4997ddc8b8db1ce56a0009",
-                "reference": "6a62f2b394e042884e4997ddc8b8db1ce56a0009",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/729861f66944204f5b446ee1cb156f02f2a439a6",
+                "reference": "729861f66944204f5b446ee1cb156f02f2a439a6",
                 "shasum": ""
             },
             "require": {
@@ -5361,12 +5361,12 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.3.7",
+                "phpunit/php-code-coverage": "^12.3.8",
                 "phpunit/php-file-iterator": "^6.0.0",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
-                "sebastian/cli-parser": "^4.1.0",
+                "sebastian/cli-parser": "^4.2.0",
                 "sebastian/comparator": "^7.1.3",
                 "sebastian/diff": "^7.0.0",
                 "sebastian/environment": "^8.0.3",
@@ -5415,7 +5415,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.3.11"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.3.12"
             },
             "funding": [
                 {
@@ -5439,7 +5439,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-14T06:21:44+00:00"
+            "time": "2025-09-21T12:23:01+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -5805,16 +5805,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "76432aafc58d50691a00d86d0632f1217a47b688"
+                "reference": "b759164a8e02263784b662889cc6cbb686077af6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/76432aafc58d50691a00d86d0632f1217a47b688",
-                "reference": "76432aafc58d50691a00d86d0632f1217a47b688",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/b759164a8e02263784b662889cc6cbb686077af6",
+                "reference": "b759164a8e02263784b662889cc6cbb686077af6",
                 "shasum": ""
             },
             "require": {
@@ -5871,15 +5871,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:56:42+00:00"
+            "time": "2025-09-22T05:39:29+00:00"
         },
         {
             "name": "sebastian/global-state",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,6 @@
     <env name="BASE_URI" value="" />
     <env name="CACHE" value="null" />
     <env name="DISCOVERY_CACHE" value="true" />
+    <env name="SIGNING_KEY" value="pJLVJ5fKA4u0GKf6JlNk226Sy1MTJFWKd/+PxNVZqZE=" />
   </php>
 </phpunit>

--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -29,178 +29,178 @@ use function Tempest\root_path;
 #[Priority(Priority::HIGH)]
 class Middleware implements HttpMiddleware
 {
-  public Session $session {
-    get => get(Session::class);
-  }
-
-  public function __construct(
-    public readonly ResponseFactory $inertia,
-    private readonly Validator $validator,
-  ) {}
-
-  /**
-   * The root template loaded on the first page visit.
-   *
-   * @see https://inertiajs.com/server-side-setup#root-template
-   */
-  protected string $rootView = 'inertia.view.php';
-
-  /**
-   * Determines the current asset version.
-   *
-   * @see https://inertiajs.com/asset-versioning
-   */
-  public function version(): ?string
-  {
-    if (env('VITE_ASSET_URL')) {
-      return hash('xxh128', (string) env('VITE_ASSET_URL'));
+    public Session $session {
+        get => get(Session::class);
     }
 
-    $manifestPathFromEnv = env('TEMPEST_PLUGIN_CONFIGURATION_PATH');
+    public function __construct(
+        public readonly ResponseFactory $inertia,
+        private readonly Validator $validator,
+    ) {}
 
-    if ($manifestPathFromEnv && file_exists($manifestPathFromEnv)) {
-      return hash_file('xxh128', $manifestPathFromEnv);
-    }
+    /**
+     * The root template loaded on the first page visit.
+     *
+     * @see https://inertiajs.com/server-side-setup#root-template
+     */
+    protected string $rootView = 'inertia.view.php';
 
-    $manifest = root_path('/public/build/manifest.json');
-    if (file_exists($manifest)) {
-      return hash_file('xxh128', $manifest);
-    }
-
-    return null;
-  }
-
-  /**
-   * Defines the props that are shared by default.
-   *
-   * @see https://inertiajs.com/shared-data
-   *
-   * @return array<string, mixed>
-   */
-  public function share(Request $request): array
-  {
-    return [
-      'errors' => $this->inertia->always($this->resolveValidationErrors($request)),
-    ];
-  }
-
-  /**
-   * Sets the root template loaded on the first page visit.
-   *
-   * @see https://inertiajs.com/server-side-setup#root-template
-   */
-  public function rootView(Request $request): string
-  {
-    return $this->rootView;
-  }
-
-  /**
-   * Define a callback that returns the relative URL.
-   */
-  public function urlResolver(): ?Closure
-  {
-    return null;
-  }
-
-  /**
-   * This is the core of the Inertia middleware. It checks for Inertia headers,
-   * handles asset versioning, and modifies the response accordingly.
-   */
-  #[Override]
-  public function __invoke(Request $request, HttpMiddlewareCallable $next): Response
-  {
-    $this->inertia->setRootView($this->rootView($request));
-    $this->inertia->share($this->share($request));
-    $this->inertia->version($this->version());
-
-    $urlResolver = $this->urlResolver();
-    if ($urlResolver instanceof \Closure) {
-      $this->inertia->resolveUrlUsing($urlResolver);
-    }
-
-    try {
-      $response = $next($request);
-    } catch (ControllerActionHadNoReturn) {
-      if ($request->headers->has(Header::INERTIA)) {
-        $response = $this->onEmptyResponse();
-      } else {
-        return new Ok();
-      }
-    }
-
-    $response->addHeader('Vary', Header::INERTIA);
-
-    if (! $request->headers->has(Header::INERTIA)) {
-      return $response;
-    }
-
-    $currentVersion = $this->inertia->getVersion();
-    $clientVersion = $request->headers->get(Header::VERSION) ?? '';
-
-    if ($request->method === Method::GET && $clientVersion && $clientVersion !== $currentVersion) {
-      $this->session->reflash();
-
-      return $this->inertia->location($request->uri);
-    }
-
-    if (
-      $response->status === Status::FOUND &&
-          in_array($request->method, [Method::POST, Method::PUT, Method::PATCH], true)
-    ) {
-      $response->setStatus(Status::SEE_OTHER);
-    }
-
-    return $response;
-  }
-
-  /**
-   * Handle empty responses.
-   */
-  protected function onEmptyResponse(): Response
-  {
-    return new Back();
-  }
-
-  /**
-   * Handle version changes.
-   */
-  public function onVersionChange(Request $request): Response
-  {
-    $this->session?->reflash();
-
-    return $this->inertia->location($request->uri);
-  }
-
-  /**
-   * Resolve validation errors for client-side use.
-   */
-  public function resolveValidationErrors(Request $request): object
-  {
-    $allErrors = $this->session->get(Session::VALIDATION_ERRORS) ?? [];
-
-    if ($allErrors === []) {
-      return new \stdClass();
-    }
-
-    $processedErrors = [];
-    foreach ($allErrors as $field => $rules) {
-      if (is_array($rules) && $rules !== [] && $rules[0] instanceof Rule) {
-        $message = $this->validator->getErrorMessage($rules[0], 'Value');
-
-        if ($message) {
-          $processedErrors[$field] = $message;
+    /**
+     * Determines the current asset version.
+     *
+     * @see https://inertiajs.com/asset-versioning
+     */
+    public function version(): ?string
+    {
+        if (env('VITE_ASSET_URL')) {
+            return hash('xxh128', (string) env('VITE_ASSET_URL'));
         }
-      }
+
+        $manifestPathFromEnv = env('TEMPEST_PLUGIN_CONFIGURATION_PATH');
+
+        if ($manifestPathFromEnv && file_exists($manifestPathFromEnv)) {
+            return hash_file('xxh128', $manifestPathFromEnv);
+        }
+
+        $manifest = root_path('/public/build/manifest.json');
+        if (file_exists($manifest)) {
+            return hash_file('xxh128', $manifest);
+        }
+
+        return null;
     }
 
-    $errorBag = $request->headers->get(Header::ERROR_BAG);
-
-    if ($errorBag) {
-      return (object) [
-        $errorBag => (object) $processedErrors,
-      ];
+    /**
+     * Defines the props that are shared by default.
+     *
+     * @see https://inertiajs.com/shared-data
+     *
+     * @return array<string, mixed>
+     */
+    public function share(Request $request): array
+    {
+        return [
+            'errors' => $this->inertia->always($this->resolveValidationErrors($request)),
+        ];
     }
 
-    return (object) $processedErrors;
-  }
+    /**
+     * Sets the root template loaded on the first page visit.
+     *
+     * @see https://inertiajs.com/server-side-setup#root-template
+     */
+    public function rootView(Request $request): string
+    {
+        return $this->rootView;
+    }
+
+    /**
+     * Define a callback that returns the relative URL.
+     */
+    public function urlResolver(): ?Closure
+    {
+        return null;
+    }
+
+    /**
+     * This is the core of the Inertia middleware. It checks for Inertia headers,
+     * handles asset versioning, and modifies the response accordingly.
+     */
+    #[Override]
+    public function __invoke(Request $request, HttpMiddlewareCallable $next): Response
+    {
+        $this->inertia->setRootView($this->rootView($request));
+        $this->inertia->share($this->share($request));
+        $this->inertia->version($this->version());
+
+        $urlResolver = $this->urlResolver();
+        if ($urlResolver instanceof \Closure) {
+            $this->inertia->resolveUrlUsing($urlResolver);
+        }
+
+        try {
+            $response = $next($request);
+        } catch (ControllerActionHadNoReturn) {
+            if ($request->headers->has(Header::INERTIA)) {
+                $response = $this->onEmptyResponse();
+            } else {
+                return new Ok();
+            }
+        }
+
+        $response->addHeader('Vary', Header::INERTIA);
+
+        if (!$request->headers->has(Header::INERTIA)) {
+            return $response;
+        }
+
+        $currentVersion = $this->inertia->getVersion();
+        $clientVersion = $request->headers->get(Header::VERSION) ?? '';
+
+        if ($request->method === Method::GET && $clientVersion && $clientVersion !== $currentVersion) {
+            $this->session->reflash();
+
+            return $this->inertia->location($request->uri);
+        }
+
+        if (
+            $response->status === Status::FOUND &&
+                in_array($request->method, [Method::POST, Method::PUT, Method::PATCH], true)
+        ) {
+            $response->setStatus(Status::SEE_OTHER);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Handle empty responses.
+     */
+    protected function onEmptyResponse(): Response
+    {
+        return new Back();
+    }
+
+    /**
+     * Handle version changes.
+     */
+    public function onVersionChange(Request $request): Response
+    {
+        $this->session?->reflash();
+
+        return $this->inertia->location($request->uri);
+    }
+
+    /**
+     * Resolve validation errors for client-side use.
+     */
+    public function resolveValidationErrors(Request $request): object
+    {
+        $allErrors = $this->session->get(Session::VALIDATION_ERRORS) ?? [];
+
+        if ($allErrors === []) {
+            return new \stdClass();
+        }
+
+        $processedErrors = [];
+        foreach ($allErrors as $field => $rules) {
+            if (is_array($rules) && $rules !== [] && $rules[0] instanceof Rule) {
+                $message = $this->validator->getErrorMessage($rules[0], 'Value');
+
+                if ($message !== '' && $message !== '0') {
+                    $processedErrors[$field] = $message;
+                }
+            }
+        }
+
+        $errorBag = $request->headers->get(Header::ERROR_BAG);
+
+        if ($errorBag) {
+            return (object) [
+                $errorBag => (object) $processedErrors,
+            ];
+        }
+
+        return (object) $processedErrors;
+    }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -372,7 +372,7 @@ final class Response implements HttpResponse
                 'deepMergeProps' => $deepMergeProps,
                 'matchPropsOn' => $matchPropsOn,
             ],
-            fn($prop) => $prop !== [],
+            fn(array $prop) => $prop !== [],
         );
     }
 

--- a/tests/Integration/HistoryTest.php
+++ b/tests/Integration/HistoryTest.php
@@ -7,137 +7,137 @@ use Inertia\Support\Header;
 use Inertia\Tests\Fixtures\TestController;
 use Inertia\Tests\TestCase;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 class HistoryTest extends TestCase
 {
-    public function test_the_history_is_not_encrypted_or_cleared_by_default(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'basicRenderWithMiddleware']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+  public function test_the_history_is_not_encrypted_or_cleared_by_default(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'basicRenderWithMiddleware']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
 
-        $page = $response->body;
+    $page = $response->body;
 
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertFalse($page['clearHistory']);
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertFalse($page['encryptHistory']);
+    $this->assertFalse($page['clearHistory']);
+  }
+
+  public function test_the_history_can_be_encrypted(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'encryptHistory']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertTrue($page['encryptHistory']);
+  }
+
+  public function test_the_history_can_be_encrypted_via_middleware(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'encryptHistoryWithMiddleware']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertTrue($page['encryptHistory']);
+  }
+
+  public function test_the_history_can_be_encrypted_globally(): void
+  {
+    $config = $this->container->get(InertiaConfig::class);
+
+    $originalValue = $config->history->encrypt;
+    $config->history->encrypt = true;
+
+    try {
+      $response = $this->http->get(
+        uri: uri([TestController::class, 'basicRenderWithMiddleware']),
+        headers: [
+          Header::INERTIA => 'true',
+        ],
+      );
+
+      $page = $response->body;
+
+      $this->assertSame('User/Edit', $page['component']);
+      $this->assertTrue($page['encryptHistory']);
+    } finally {
+      $config->history->encrypt = $originalValue;
     }
+  }
 
-    public function test_the_history_can_be_encrypted(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'encryptHistory']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+  public function test_the_history_can_be_encrypted_globally_and_overridden(): void
+  {
+    $config = $this->container->get(InertiaConfig::class);
+    $originalValue = $config->history->encrypt;
+    $config->history->encrypt = true;
 
-        $page = $response->body;
+    try {
+      $response = $this->http->get(
+        uri: uri([TestController::class, 'encryptHistoryOverride']),
+        headers: [
+          Header::INERTIA => 'true',
+        ],
+      );
 
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertTrue($page['encryptHistory']);
+      $page = $response->body;
+
+      $this->assertSame('User/Edit', $page['component']);
+      $this->assertFalse($page['encryptHistory']);
+    } finally {
+      $config->history->encrypt = $originalValue;
     }
+  }
 
-    public function test_the_history_can_be_encrypted_via_middleware(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'encryptHistoryWithMiddleware']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+  public function test_the_history_can_be_cleared(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'clearHistory']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
 
-        $page = $response->body;
+    $page = $response->body;
 
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertTrue($page['encryptHistory']);
-    }
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertTrue($page['clearHistory']);
+  }
 
-    public function test_the_history_can_be_encrypted_globally(): void
-    {
-        $config = $this->container->get(InertiaConfig::class);
+  public function test_the_history_can_be_cleared_when_redirecting(): void
+  {
+    $this->http->get(
+      uri: uri([TestController::class, 'clearHistoryAndRedirect']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
 
-        $originalValue = $config->history->encrypt;
-        $config->history->encrypt = true;
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'basicRender']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
 
-        try {
-            $response = $this->http->get(
-                uri: uri([TestController::class, 'basicRenderWithMiddleware']),
-                headers: [
-                    Header::INERTIA => 'true',
-                ],
-            );
+    $page = $response->body;
 
-            $page = $response->body;
-
-            $this->assertSame('User/Edit', $page['component']);
-            $this->assertTrue($page['encryptHistory']);
-        } finally {
-            $config->history->encrypt = $originalValue;
-        }
-    }
-
-    public function test_the_history_can_be_encrypted_globally_and_overridden(): void
-    {
-        $config = $this->container->get(InertiaConfig::class);
-        $originalValue = $config->history->encrypt;
-        $config->history->encrypt = true;
-
-        try {
-            $response = $this->http->get(
-                uri: uri([TestController::class, 'encryptHistoryOverride']),
-                headers: [
-                    Header::INERTIA => 'true',
-                ],
-            );
-
-            $page = $response->body;
-
-            $this->assertSame('User/Edit', $page['component']);
-            $this->assertFalse($page['encryptHistory']);
-        } finally {
-            $config->history->encrypt = $originalValue;
-        }
-    }
-
-    public function test_the_history_can_be_cleared(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'clearHistory']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertTrue($page['clearHistory']);
-    }
-
-    public function test_the_history_can_be_cleared_when_redirecting(): void
-    {
-        $this->http->get(
-            uri: uri([TestController::class, 'clearHistoryAndRedirect']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'basicRender']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertTrue($page['clearHistory']);
-    }
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertTrue($page['clearHistory']);
+  }
 }

--- a/tests/Integration/HistoryTest.php
+++ b/tests/Integration/HistoryTest.php
@@ -11,133 +11,133 @@ use function Tempest\Router\uri;
 
 class HistoryTest extends TestCase
 {
-  public function test_the_history_is_not_encrypted_or_cleared_by_default(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'basicRenderWithMiddleware']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
+    public function test_the_history_is_not_encrypted_or_cleared_by_default(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRenderWithMiddleware']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
-    $page = $response->body;
+        $page = $response->body;
 
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertFalse($page['encryptHistory']);
-    $this->assertFalse($page['clearHistory']);
-  }
-
-  public function test_the_history_can_be_encrypted(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'encryptHistory']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertTrue($page['encryptHistory']);
-  }
-
-  public function test_the_history_can_be_encrypted_via_middleware(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'encryptHistoryWithMiddleware']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertTrue($page['encryptHistory']);
-  }
-
-  public function test_the_history_can_be_encrypted_globally(): void
-  {
-    $config = $this->container->get(InertiaConfig::class);
-
-    $originalValue = $config->history->encrypt;
-    $config->history->encrypt = true;
-
-    try {
-      $response = $this->http->get(
-        uri: uri([TestController::class, 'basicRenderWithMiddleware']),
-        headers: [
-          Header::INERTIA => 'true',
-        ],
-      );
-
-      $page = $response->body;
-
-      $this->assertSame('User/Edit', $page['component']);
-      $this->assertTrue($page['encryptHistory']);
-    } finally {
-      $config->history->encrypt = $originalValue;
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertFalse($page['encryptHistory']);
+        $this->assertFalse($page['clearHistory']);
     }
-  }
 
-  public function test_the_history_can_be_encrypted_globally_and_overridden(): void
-  {
-    $config = $this->container->get(InertiaConfig::class);
-    $originalValue = $config->history->encrypt;
-    $config->history->encrypt = true;
+    public function test_the_history_can_be_encrypted(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'encryptHistory']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
-    try {
-      $response = $this->http->get(
-        uri: uri([TestController::class, 'encryptHistoryOverride']),
-        headers: [
-          Header::INERTIA => 'true',
-        ],
-      );
+        $page = $response->body;
 
-      $page = $response->body;
-
-      $this->assertSame('User/Edit', $page['component']);
-      $this->assertFalse($page['encryptHistory']);
-    } finally {
-      $config->history->encrypt = $originalValue;
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertTrue($page['encryptHistory']);
     }
-  }
 
-  public function test_the_history_can_be_cleared(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'clearHistory']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
+    public function test_the_history_can_be_encrypted_via_middleware(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'encryptHistoryWithMiddleware']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
-    $page = $response->body;
+        $page = $response->body;
 
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertTrue($page['clearHistory']);
-  }
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertTrue($page['encryptHistory']);
+    }
 
-  public function test_the_history_can_be_cleared_when_redirecting(): void
-  {
-    $this->http->get(
-      uri: uri([TestController::class, 'clearHistoryAndRedirect']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
+    public function test_the_history_can_be_encrypted_globally(): void
+    {
+        $config = $this->container->get(InertiaConfig::class);
 
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'basicRender']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
+        $originalValue = $config->history->encrypt;
+        $config->history->encrypt = true;
 
-    $page = $response->body;
+        try {
+            $response = $this->http->get(
+                uri: uri([TestController::class, 'basicRenderWithMiddleware']),
+                headers: [
+                    Header::INERTIA => 'true',
+                ],
+            );
 
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertTrue($page['clearHistory']);
-  }
+            $page = $response->body;
+
+            $this->assertSame('User/Edit', $page['component']);
+            $this->assertTrue($page['encryptHistory']);
+        } finally {
+            $config->history->encrypt = $originalValue;
+        }
+    }
+
+    public function test_the_history_can_be_encrypted_globally_and_overridden(): void
+    {
+        $config = $this->container->get(InertiaConfig::class);
+        $originalValue = $config->history->encrypt;
+        $config->history->encrypt = true;
+
+        try {
+            $response = $this->http->get(
+                uri: uri([TestController::class, 'encryptHistoryOverride']),
+                headers: [
+                    Header::INERTIA => 'true',
+                ],
+            );
+
+            $page = $response->body;
+
+            $this->assertSame('User/Edit', $page['component']);
+            $this->assertFalse($page['encryptHistory']);
+        } finally {
+            $config->history->encrypt = $originalValue;
+        }
+    }
+
+    public function test_the_history_can_be_cleared(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'clearHistory']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertTrue($page['clearHistory']);
+    }
+
+    public function test_the_history_can_be_cleared_when_redirecting(): void
+    {
+        $this->http->get(
+            uri: uri([TestController::class, 'clearHistoryAndRedirect']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRender']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertTrue($page['clearHistory']);
+    }
 }

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -22,335 +22,335 @@ use function Tempest\Router\uri;
 
 class MiddlewareTest extends TestCase
 {
-  #[\Override]
-  protected function setUp(): void
-  {
-    parent::setUp();
-    ExampleMiddleware::$runCount = 0;
-    TestController::$voidActionCalled = false;
-  }
-
-  public function test_no_response_value_by_default_means_automatically_redirecting_back_for_inertia_requests(): void
-  {
-    $response = $this->http->put(
-      uri: uri([TestController::class, 'voidPutAction']),
-      headers: [
-        Header::INERTIA => 'true',
-        'Content-Type' => 'application/json',
-        'Referer' => '/foo',
-      ],
-    );
-
-    $response->assertStatus(Status::SEE_OTHER);
-    $this->assertSame('/foo', $response->headers['Location']->values[0]);
-    $this->assertTrue(TestController::$voidActionCalled, 'The controller action was not called.');
-  }
-
-  public function test_no_response_value_can_be_customized_by_overriding_the_middleware_method(): void
-  {
-    $this->expectException(LogicException::class);
-    $this->expectExceptionMessage('An empty Inertia response was returned.');
-
-    $this->http->get(
-      uri: uri([TestController::class, 'customEmptyResponseAction']),
-      headers: [
-        Header::INERTIA => 'true',
-        'Content-Type' => 'application/json',
-      ],
-    );
-  }
-
-  public function test_no_response_means_no_response_for_non_inertia_requests(): void
-  {
-    $response = $this->http->put(
-      uri: uri([TestController::class, 'voidPutAction']),
-      headers: [
-        'Content-Type' => 'application/json',
-      ],
-    );
-
-    $this->assertTrue(TestController::$voidActionCalled, 'The controller action was not called.');
-    $response->assertStatus(Status::OK);
-    $this->assertEmpty($response->body);
-  }
-
-  public function test_the_version_is_optional(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'basicRender']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-
-    $response->assertStatus(Status::OK);
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Edit', $page['component']);
-  }
-
-  public function test_the_version_can_be_a_number(): void
-  {
-    $version = 1597347897973;
-
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'numericVersion']),
-      headers: [
-        Header::INERTIA => 'true',
-        Header::VERSION => (string) $version,
-      ],
-    );
-
-    $page = $response->body;
-
-    $response->assertStatus(Status::OK);
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Edit', $page['component']);
-  }
-
-  public function test_the_version_can_be_a_string(): void
-  {
-    $version = 'foo-version';
-
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'stringVersion']),
-      headers: [
-        Header::INERTIA => 'true',
-        Header::VERSION => $version,
-      ],
-    );
-
-    $page = $response->body;
-
-    $response->assertStatus(Status::OK);
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Edit', $page['component']);
-  }
-
-  public function test_it_will_instruct_inertia_to_reload_on_a_version_mismatch(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'stringVersion']),
-      headers: [
-        Header::INERTIA => 'true',
-        Header::VERSION => 'a-different-version',
-      ],
-    );
-
-    $response->assertStatus(Status::CONFLICT);
-    $this->assertSame('/string-version-test', $response->headers[Header::LOCATION]->values[0]);
-    $this->assertEmpty($response->body);
-  }
-
-  public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-
-    $response->assertStatus(Status::OK);
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('/my-custom-url', $page['url']);
-  }
-
-  public function test_validation_errors_are_registered_as_of_default(): void
-  {
-    $middleware = $this->container->get(Middleware::class);
-    $request = $this->container->get(Request::class);
-    $this->assertInstanceOf(Middleware::class, $middleware);
-
-    $sharedData = $middleware->share($request);
-
-    $this->assertArrayHasKey('errors', $sharedData);
-    $this->assertInstanceOf(AlwaysProp::class, $sharedData['errors']);
-  }
-
-  public function test_validation_errors_can_be_empty(): void
-  {
-    $middleware = $this->container->get(Middleware::class);
-    $request = $this->container->get(Request::class);
-    $this->assertInstanceOf(Middleware::class, $middleware);
-
-    $sharedData = $middleware->share($request);
-    $errors = $sharedData['errors']();
-
-    $this->assertIsObject($errors);
-    $this->assertEmpty(get_object_vars($errors));
-  }
-
-  public function test_validation_errors_are_returned_in_the_correct_format(): void
-  {
-    $session = $this->container->get(Session::class);
-
-    $validationErrors = [
-      'email' => [new IsEmail()],
-    ];
-    $this->assertInstanceOf(Session::class, $session);
-    $session->set(Session::VALIDATION_ERRORS, $validationErrors);
-
-    $middleware = $this->container->get(Middleware::class);
-    $request = $this->container->get(Request::class);
-    $this->assertInstanceOf(Middleware::class, $middleware);
-
-    $sharedData = $middleware->share($request);
-    $errors = $sharedData['errors']();
-
-    $this->assertIsObject($errors);
-    $this->assertSame('Value must be a valid email address', $errors->email);
-  }
-
-  public function test_default_validation_errors_can_be_overwritten(): void
-  {
-    $session = $this->container->get(Session::class);
-    $this->assertInstanceOf(Session::class, $session);
-    $session->set(Session::VALIDATION_ERRORS, ['name' => ['This should be overwritten.']]);
-
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'overwriteErrorsProp']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertArrayHasKey('errors', $page['props']);
-    $this->assertSame('foo', $page['props']['errors']);
-  }
-
-  public function test_validation_errors_are_scoped_to_error_bag_header(): void
-  {
-    $session = $this->container->get(Session::class);
-
-    $validationErrors = [
-      'email' => [new IsEmail()],
-    ];
-    $this->assertInstanceOf(Session::class, $session);
-    $session->set(Session::VALIDATION_ERRORS, $validationErrors);
-
-    $middleware = $this->container->get(Middleware::class);
-    $request = $this->makeRequest(headers: [Header::ERROR_BAG => 'example']);
-    $this->assertInstanceOf(Middleware::class, $middleware);
-
-    $sharedData = $middleware->share($request);
-    $errors = $sharedData['errors']();
-
-    $this->assertIsObject($errors);
-    $this->assertObjectHasProperty('example', $errors);
-    $this->assertSame('Value must be a valid email address', $errors->example->email);
-  }
-
-  public function test_middleware_can_change_the_root_view_via_a_property(): void
-  {
-    $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']));
-
-    $response->assertStatus(Status::OK);
-    $this->assertInstanceOf(InertiaView::class, $response->body);
-    $this->assertSame('welcome', $response->body->path);
-  }
-
-  public function test_middleware_can_change_the_root_view_by_overriding_the_rootview_method(): void
-  {
-    $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']));
-
-    $response->assertStatus(Status::OK);
-    $this->assertInstanceOf(InertiaView::class, $response->body);
-    $this->assertSame('welcome', $response->body->path);
-  }
-
-  public function test_determine_the_version_by_a_hash_of_the_asset_url(): void
-  {
-    $url = 'https://example.com/assets';
-    $originalEnv = getenv('VITE_ASSET_URL');
-    putenv("VITE_ASSET_URL={$url}");
-
-    try {
-      $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
-
-      $page = $response->body->inertia['page'];
-
-      $response->assertStatus(Status::OK);
-      $this->assertInstanceOf(InertiaView::class, $response->body);
-      $this->assertSame(hash('xxh128', $url), $page['version']);
-    } finally {
-      if ($originalEnv === false) {
-        putenv('VITE_ASSET_URL');
-      } else {
-        putenv("VITE_ASSET_URL={$originalEnv}");
-      }
-    }
-  }
-
-  public function test_determine_the_version_by_a_hash_of_the_vite_manifest(): void
-  {
-    $manifestPath = root_path('public/build/manifest.json');
-    $directoryPath = dirname($manifestPath);
-    $contents = json_encode(['vite' => true]);
-
-    if (! is_dir($directoryPath)) {
-      mkdir($directoryPath, 0o777, true);
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        ExampleMiddleware::$runCount = 0;
+        TestController::$voidActionCalled = false;
     }
 
-    file_put_contents($manifestPath, $contents);
+    public function test_no_response_value_by_default_means_automatically_redirecting_back_for_inertia_requests(): void
+    {
+        $response = $this->http->put(
+            uri: uri([TestController::class, 'voidPutAction']),
+            headers: [
+                Header::INERTIA => 'true',
+                'Content-Type' => 'application/json',
+                'Referer' => '/foo',
+            ],
+        );
 
-    try {
-      $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
-
-      $page = $response->body->inertia['page'];
-
-      $response->assertStatus(Status::OK);
-      $this->assertInstanceOf(InertiaView::class, $response->body);
-      $this->assertSame(hash_file('xxh128', $manifestPath), $page['version']);
-    } finally {
-      unlink($manifestPath);
-      rmdir($directoryPath);
+        $response->assertStatus(Status::SEE_OTHER);
+        $this->assertSame('/foo', $response->headers['Location']->values[0]);
+        $this->assertTrue(TestController::$voidActionCalled, 'The controller action was not called.');
     }
-  }
 
-  public function test_determine_the_version_by_a_hash_of_the_vite_manifest_from_env_path(): void
-  {
-    $manifestPath = root_path('temp-manifest.json');
-    $manifestContents = json_encode(['vite' => true]);
-    file_put_contents($manifestPath, $manifestContents);
+    public function test_no_response_value_can_be_customized_by_overriding_the_middleware_method(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('An empty Inertia response was returned.');
 
-    $originalEnv = getenv('TEMPEST_PLUGIN_CONFIGURATION_PATH');
-    putenv("TEMPEST_PLUGIN_CONFIGURATION_PATH={$manifestPath}");
-
-    $kernel = FrameworkKernel::boot($this->root, discoveryLocations: $this->discoveryLocations);
-    $http = new HttpRouterTester($kernel->container);
-
-    try {
-      $response = $http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
-      $page = $response->body->inertia['page'];
-
-      $response->assertStatus(Status::OK);
-      $this->assertInstanceOf(InertiaView::class, $response->body);
-      $this->assertSame(hash_file('xxh128', $manifestPath), $page['version']);
-    } finally {
-      unlink($manifestPath);
-      if ($originalEnv === false) {
-        putenv('TEMPEST_PLUGIN_CONFIGURATION_PATH');
-      } else {
-        putenv("TEMPEST_PLUGIN_CONFIGURATION_PATH={$originalEnv}");
-      }
+        $this->http->get(
+            uri: uri([TestController::class, 'customEmptyResponseAction']),
+            headers: [
+                Header::INERTIA => 'true',
+                'Content-Type' => 'application/json',
+            ],
+        );
     }
-  }
 
-  public function test_extended_middleware_only_runs_once(): void
-  {
-    $this->container->singleton(Middleware::class, fn () => $this->container->get(ExampleMiddleware::class));
+    public function test_no_response_means_no_response_for_non_inertia_requests(): void
+    {
+        $response = $this->http->put(
+            uri: uri([TestController::class, 'voidPutAction']),
+            headers: [
+                'Content-Type' => 'application/json',
+            ],
+        );
 
-    $this->http->get(uri: uri([TestController::class, 'basicRender']));
+        $this->assertTrue(TestController::$voidActionCalled, 'The controller action was not called.');
+        $response->assertStatus(Status::OK);
+        $this->assertEmpty($response->body);
+    }
 
-    $this->assertSame(1, ExampleMiddleware::$runCount);
-  }
+    public function test_the_version_is_optional(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRender']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+
+        $response->assertStatus(Status::OK);
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Edit', $page['component']);
+    }
+
+    public function test_the_version_can_be_a_number(): void
+    {
+        $version = 1597347897973;
+
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'numericVersion']),
+            headers: [
+                Header::INERTIA => 'true',
+                Header::VERSION => (string) $version,
+            ],
+        );
+
+        $page = $response->body;
+
+        $response->assertStatus(Status::OK);
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Edit', $page['component']);
+    }
+
+    public function test_the_version_can_be_a_string(): void
+    {
+        $version = 'foo-version';
+
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'stringVersion']),
+            headers: [
+                Header::INERTIA => 'true',
+                Header::VERSION => $version,
+            ],
+        );
+
+        $page = $response->body;
+
+        $response->assertStatus(Status::OK);
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Edit', $page['component']);
+    }
+
+    public function test_it_will_instruct_inertia_to_reload_on_a_version_mismatch(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'stringVersion']),
+            headers: [
+                Header::INERTIA => 'true',
+                Header::VERSION => 'a-different-version',
+            ],
+        );
+
+        $response->assertStatus(Status::CONFLICT);
+        $this->assertSame('/string-version-test', $response->headers[Header::LOCATION]->values[0]);
+        $this->assertEmpty($response->body);
+    }
+
+    public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+
+        $response->assertStatus(Status::OK);
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('/my-custom-url', $page['url']);
+    }
+
+    public function test_validation_errors_are_registered_as_of_default(): void
+    {
+        $middleware = $this->container->get(Middleware::class);
+        $request = $this->container->get(Request::class);
+        $this->assertInstanceOf(Middleware::class, $middleware);
+
+        $sharedData = $middleware->share($request);
+
+        $this->assertArrayHasKey('errors', $sharedData);
+        $this->assertInstanceOf(AlwaysProp::class, $sharedData['errors']);
+    }
+
+    public function test_validation_errors_can_be_empty(): void
+    {
+        $middleware = $this->container->get(Middleware::class);
+        $request = $this->container->get(Request::class);
+        $this->assertInstanceOf(Middleware::class, $middleware);
+
+        $sharedData = $middleware->share($request);
+        $errors = $sharedData['errors']();
+
+        $this->assertIsObject($errors);
+        $this->assertEmpty(get_object_vars($errors));
+    }
+
+    public function test_validation_errors_are_returned_in_the_correct_format(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $validationErrors = [
+            'email' => [new IsEmail()],
+        ];
+        $this->assertInstanceOf(Session::class, $session);
+        $session->set(Session::VALIDATION_ERRORS, $validationErrors);
+
+        $middleware = $this->container->get(Middleware::class);
+        $request = $this->container->get(Request::class);
+        $this->assertInstanceOf(Middleware::class, $middleware);
+
+        $sharedData = $middleware->share($request);
+        $errors = $sharedData['errors']();
+
+        $this->assertIsObject($errors);
+        $this->assertSame('Value must be a valid email address', $errors->email);
+    }
+
+    public function test_default_validation_errors_can_be_overwritten(): void
+    {
+        $session = $this->container->get(Session::class);
+        $this->assertInstanceOf(Session::class, $session);
+        $session->set(Session::VALIDATION_ERRORS, ['name' => ['This should be overwritten.']]);
+
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'overwriteErrorsProp']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayHasKey('errors', $page['props']);
+        $this->assertSame('foo', $page['props']['errors']);
+    }
+
+    public function test_validation_errors_are_scoped_to_error_bag_header(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $validationErrors = [
+            'email' => [new IsEmail()],
+        ];
+        $this->assertInstanceOf(Session::class, $session);
+        $session->set(Session::VALIDATION_ERRORS, $validationErrors);
+
+        $middleware = $this->container->get(Middleware::class);
+        $request = $this->makeRequest(headers: [Header::ERROR_BAG => 'example']);
+        $this->assertInstanceOf(Middleware::class, $middleware);
+
+        $sharedData = $middleware->share($request);
+        $errors = $sharedData['errors']();
+
+        $this->assertIsObject($errors);
+        $this->assertObjectHasProperty('example', $errors);
+        $this->assertSame('Value must be a valid email address', $errors->example->email);
+    }
+
+    public function test_middleware_can_change_the_root_view_via_a_property(): void
+    {
+        $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']));
+
+        $response->assertStatus(Status::OK);
+        $this->assertInstanceOf(InertiaView::class, $response->body);
+        $this->assertSame('welcome', $response->body->path);
+    }
+
+    public function test_middleware_can_change_the_root_view_by_overriding_the_rootview_method(): void
+    {
+        $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']));
+
+        $response->assertStatus(Status::OK);
+        $this->assertInstanceOf(InertiaView::class, $response->body);
+        $this->assertSame('welcome', $response->body->path);
+    }
+
+    public function test_determine_the_version_by_a_hash_of_the_asset_url(): void
+    {
+        $url = 'https://example.com/assets';
+        $originalEnv = getenv('VITE_ASSET_URL');
+        putenv("VITE_ASSET_URL={$url}");
+
+        try {
+            $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
+
+            $page = $response->body->inertia['page'];
+
+            $response->assertStatus(Status::OK);
+            $this->assertInstanceOf(InertiaView::class, $response->body);
+            $this->assertSame(hash('xxh128', $url), $page['version']);
+        } finally {
+            if ($originalEnv === false) {
+                putenv('VITE_ASSET_URL');
+            } else {
+                putenv("VITE_ASSET_URL={$originalEnv}");
+            }
+        }
+    }
+
+    public function test_determine_the_version_by_a_hash_of_the_vite_manifest(): void
+    {
+        $manifestPath = root_path('public/build/manifest.json');
+        $directoryPath = dirname($manifestPath);
+        $contents = json_encode(['vite' => true]);
+
+        if (!is_dir($directoryPath)) {
+            mkdir($directoryPath, 0o777, true);
+        }
+
+        file_put_contents($manifestPath, $contents);
+
+        try {
+            $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
+
+            $page = $response->body->inertia['page'];
+
+            $response->assertStatus(Status::OK);
+            $this->assertInstanceOf(InertiaView::class, $response->body);
+            $this->assertSame(hash_file('xxh128', $manifestPath), $page['version']);
+        } finally {
+            unlink($manifestPath);
+            rmdir($directoryPath);
+        }
+    }
+
+    public function test_determine_the_version_by_a_hash_of_the_vite_manifest_from_env_path(): void
+    {
+        $manifestPath = root_path('temp-manifest.json');
+        $manifestContents = json_encode(['vite' => true]);
+        file_put_contents($manifestPath, $manifestContents);
+
+        $originalEnv = getenv('TEMPEST_PLUGIN_CONFIGURATION_PATH');
+        putenv("TEMPEST_PLUGIN_CONFIGURATION_PATH={$manifestPath}");
+
+        $kernel = FrameworkKernel::boot($this->root, discoveryLocations: $this->discoveryLocations);
+        $http = new HttpRouterTester($kernel->container);
+
+        try {
+            $response = $http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
+            $page = $response->body->inertia['page'];
+
+            $response->assertStatus(Status::OK);
+            $this->assertInstanceOf(InertiaView::class, $response->body);
+            $this->assertSame(hash_file('xxh128', $manifestPath), $page['version']);
+        } finally {
+            unlink($manifestPath);
+            if ($originalEnv === false) {
+                putenv('TEMPEST_PLUGIN_CONFIGURATION_PATH');
+            } else {
+                putenv("TEMPEST_PLUGIN_CONFIGURATION_PATH={$originalEnv}");
+            }
+        }
+    }
+
+    public function test_extended_middleware_only_runs_once(): void
+    {
+        $this->container->singleton(Middleware::class, fn() => $this->container->get(ExampleMiddleware::class));
+
+        $this->http->get(uri: uri([TestController::class, 'basicRender']));
+
+        $this->assertSame(1, ExampleMiddleware::$runCount);
+    }
 }

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -15,342 +15,342 @@ use Tempest\Http\ContentType;
 use Tempest\Http\Request;
 use Tempest\Http\Session\Session;
 use Tempest\Http\Status;
-use Tempest\Validation\Rules\Email;
+use Tempest\Validation\Rules\IsEmail;
 
 use function Tempest\root_path;
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 class MiddlewareTest extends TestCase
 {
-    #[\Override]
-    protected function setUp(): void
-    {
-        parent::setUp();
-        ExampleMiddleware::$runCount = 0;
-        TestController::$voidActionCalled = false;
+  #[\Override]
+  protected function setUp(): void
+  {
+    parent::setUp();
+    ExampleMiddleware::$runCount = 0;
+    TestController::$voidActionCalled = false;
+  }
+
+  public function test_no_response_value_by_default_means_automatically_redirecting_back_for_inertia_requests(): void
+  {
+    $response = $this->http->put(
+      uri: uri([TestController::class, 'voidPutAction']),
+      headers: [
+        Header::INERTIA => 'true',
+        'Content-Type' => 'application/json',
+        'Referer' => '/foo',
+      ],
+    );
+
+    $response->assertStatus(Status::SEE_OTHER);
+    $this->assertSame('/foo', $response->headers['Location']->values[0]);
+    $this->assertTrue(TestController::$voidActionCalled, 'The controller action was not called.');
+  }
+
+  public function test_no_response_value_can_be_customized_by_overriding_the_middleware_method(): void
+  {
+    $this->expectException(LogicException::class);
+    $this->expectExceptionMessage('An empty Inertia response was returned.');
+
+    $this->http->get(
+      uri: uri([TestController::class, 'customEmptyResponseAction']),
+      headers: [
+        Header::INERTIA => 'true',
+        'Content-Type' => 'application/json',
+      ],
+    );
+  }
+
+  public function test_no_response_means_no_response_for_non_inertia_requests(): void
+  {
+    $response = $this->http->put(
+      uri: uri([TestController::class, 'voidPutAction']),
+      headers: [
+        'Content-Type' => 'application/json',
+      ],
+    );
+
+    $this->assertTrue(TestController::$voidActionCalled, 'The controller action was not called.');
+    $response->assertStatus(Status::OK);
+    $this->assertEmpty($response->body);
+  }
+
+  public function test_the_version_is_optional(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'basicRender']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+
+    $response->assertStatus(Status::OK);
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Edit', $page['component']);
+  }
+
+  public function test_the_version_can_be_a_number(): void
+  {
+    $version = 1597347897973;
+
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'numericVersion']),
+      headers: [
+        Header::INERTIA => 'true',
+        Header::VERSION => (string) $version,
+      ],
+    );
+
+    $page = $response->body;
+
+    $response->assertStatus(Status::OK);
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Edit', $page['component']);
+  }
+
+  public function test_the_version_can_be_a_string(): void
+  {
+    $version = 'foo-version';
+
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'stringVersion']),
+      headers: [
+        Header::INERTIA => 'true',
+        Header::VERSION => $version,
+      ],
+    );
+
+    $page = $response->body;
+
+    $response->assertStatus(Status::OK);
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Edit', $page['component']);
+  }
+
+  public function test_it_will_instruct_inertia_to_reload_on_a_version_mismatch(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'stringVersion']),
+      headers: [
+        Header::INERTIA => 'true',
+        Header::VERSION => 'a-different-version',
+      ],
+    );
+
+    $response->assertStatus(Status::CONFLICT);
+    $this->assertSame('/string-version-test', $response->headers[Header::LOCATION]->values[0]);
+    $this->assertEmpty($response->body);
+  }
+
+  public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+
+    $response->assertStatus(Status::OK);
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('/my-custom-url', $page['url']);
+  }
+
+  public function test_validation_errors_are_registered_as_of_default(): void
+  {
+    $middleware = $this->container->get(Middleware::class);
+    $request = $this->container->get(Request::class);
+    $this->assertInstanceOf(Middleware::class, $middleware);
+
+    $sharedData = $middleware->share($request);
+
+    $this->assertArrayHasKey('errors', $sharedData);
+    $this->assertInstanceOf(AlwaysProp::class, $sharedData['errors']);
+  }
+
+  public function test_validation_errors_can_be_empty(): void
+  {
+    $middleware = $this->container->get(Middleware::class);
+    $request = $this->container->get(Request::class);
+    $this->assertInstanceOf(Middleware::class, $middleware);
+
+    $sharedData = $middleware->share($request);
+    $errors = $sharedData['errors']();
+
+    $this->assertIsObject($errors);
+    $this->assertEmpty(get_object_vars($errors));
+  }
+
+  public function test_validation_errors_are_returned_in_the_correct_format(): void
+  {
+    $session = $this->container->get(Session::class);
+
+    $validationErrors = [
+      'email' => [new IsEmail()],
+    ];
+    $this->assertInstanceOf(Session::class, $session);
+    $session->set(Session::VALIDATION_ERRORS, $validationErrors);
+
+    $middleware = $this->container->get(Middleware::class);
+    $request = $this->container->get(Request::class);
+    $this->assertInstanceOf(Middleware::class, $middleware);
+
+    $sharedData = $middleware->share($request);
+    $errors = $sharedData['errors']();
+
+    $this->assertIsObject($errors);
+    $this->assertSame('Value must be a valid email address', $errors->email);
+  }
+
+  public function test_default_validation_errors_can_be_overwritten(): void
+  {
+    $session = $this->container->get(Session::class);
+    $this->assertInstanceOf(Session::class, $session);
+    $session->set(Session::VALIDATION_ERRORS, ['name' => ['This should be overwritten.']]);
+
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'overwriteErrorsProp']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertArrayHasKey('errors', $page['props']);
+    $this->assertSame('foo', $page['props']['errors']);
+  }
+
+  public function test_validation_errors_are_scoped_to_error_bag_header(): void
+  {
+    $session = $this->container->get(Session::class);
+
+    $validationErrors = [
+      'email' => [new IsEmail()],
+    ];
+    $this->assertInstanceOf(Session::class, $session);
+    $session->set(Session::VALIDATION_ERRORS, $validationErrors);
+
+    $middleware = $this->container->get(Middleware::class);
+    $request = $this->makeRequest(headers: [Header::ERROR_BAG => 'example']);
+    $this->assertInstanceOf(Middleware::class, $middleware);
+
+    $sharedData = $middleware->share($request);
+    $errors = $sharedData['errors']();
+
+    $this->assertIsObject($errors);
+    $this->assertObjectHasProperty('example', $errors);
+    $this->assertSame('Value must be a valid email address', $errors->example->email);
+  }
+
+  public function test_middleware_can_change_the_root_view_via_a_property(): void
+  {
+    $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']));
+
+    $response->assertStatus(Status::OK);
+    $this->assertInstanceOf(InertiaView::class, $response->body);
+    $this->assertSame('welcome', $response->body->path);
+  }
+
+  public function test_middleware_can_change_the_root_view_by_overriding_the_rootview_method(): void
+  {
+    $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']));
+
+    $response->assertStatus(Status::OK);
+    $this->assertInstanceOf(InertiaView::class, $response->body);
+    $this->assertSame('welcome', $response->body->path);
+  }
+
+  public function test_determine_the_version_by_a_hash_of_the_asset_url(): void
+  {
+    $url = 'https://example.com/assets';
+    $originalEnv = getenv('VITE_ASSET_URL');
+    putenv("VITE_ASSET_URL={$url}");
+
+    try {
+      $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
+
+      $page = $response->body->inertia['page'];
+
+      $response->assertStatus(Status::OK);
+      $this->assertInstanceOf(InertiaView::class, $response->body);
+      $this->assertSame(hash('xxh128', $url), $page['version']);
+    } finally {
+      if ($originalEnv === false) {
+        putenv('VITE_ASSET_URL');
+      } else {
+        putenv("VITE_ASSET_URL={$originalEnv}");
+      }
+    }
+  }
+
+  public function test_determine_the_version_by_a_hash_of_the_vite_manifest(): void
+  {
+    $manifestPath = root_path('public/build/manifest.json');
+    $directoryPath = dirname($manifestPath);
+    $contents = json_encode(['vite' => true]);
+
+    if (! is_dir($directoryPath)) {
+      mkdir($directoryPath, 0o777, true);
     }
 
-    public function test_no_response_value_by_default_means_automatically_redirecting_back_for_inertia_requests(): void
-    {
-        $response = $this->http->put(
-            uri: uri([TestController::class, 'voidPutAction']),
-            headers: [
-                Header::INERTIA => 'true',
-                'Content-Type' => 'application/json',
-                'Referer' => '/foo',
-            ],
-        );
+    file_put_contents($manifestPath, $contents);
 
-        $response->assertStatus(Status::SEE_OTHER);
-        $this->assertSame('/foo', $response->headers['Location']->values[0]);
-        $this->assertTrue(TestController::$voidActionCalled, 'The controller action was not called.');
+    try {
+      $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
+
+      $page = $response->body->inertia['page'];
+
+      $response->assertStatus(Status::OK);
+      $this->assertInstanceOf(InertiaView::class, $response->body);
+      $this->assertSame(hash_file('xxh128', $manifestPath), $page['version']);
+    } finally {
+      unlink($manifestPath);
+      rmdir($directoryPath);
     }
+  }
 
-    public function test_no_response_value_can_be_customized_by_overriding_the_middleware_method(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('An empty Inertia response was returned.');
+  public function test_determine_the_version_by_a_hash_of_the_vite_manifest_from_env_path(): void
+  {
+    $manifestPath = root_path('temp-manifest.json');
+    $manifestContents = json_encode(['vite' => true]);
+    file_put_contents($manifestPath, $manifestContents);
 
-        $this->http->get(
-            uri: uri([TestController::class, 'customEmptyResponseAction']),
-            headers: [
-                Header::INERTIA => 'true',
-                'Content-Type' => 'application/json',
-            ],
-        );
+    $originalEnv = getenv('TEMPEST_PLUGIN_CONFIGURATION_PATH');
+    putenv("TEMPEST_PLUGIN_CONFIGURATION_PATH={$manifestPath}");
+
+    $kernel = FrameworkKernel::boot($this->root, discoveryLocations: $this->discoveryLocations);
+    $http = new HttpRouterTester($kernel->container);
+
+    try {
+      $response = $http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
+      $page = $response->body->inertia['page'];
+
+      $response->assertStatus(Status::OK);
+      $this->assertInstanceOf(InertiaView::class, $response->body);
+      $this->assertSame(hash_file('xxh128', $manifestPath), $page['version']);
+    } finally {
+      unlink($manifestPath);
+      if ($originalEnv === false) {
+        putenv('TEMPEST_PLUGIN_CONFIGURATION_PATH');
+      } else {
+        putenv("TEMPEST_PLUGIN_CONFIGURATION_PATH={$originalEnv}");
+      }
     }
+  }
 
-    public function test_no_response_means_no_response_for_non_inertia_requests(): void
-    {
-        $response = $this->http->put(
-            uri: uri([TestController::class, 'voidPutAction']),
-            headers: [
-                'Content-Type' => 'application/json',
-            ],
-        );
+  public function test_extended_middleware_only_runs_once(): void
+  {
+    $this->container->singleton(Middleware::class, fn () => $this->container->get(ExampleMiddleware::class));
 
-        $this->assertTrue(TestController::$voidActionCalled, 'The controller action was not called.');
-        $response->assertStatus(Status::OK);
-        $this->assertEmpty($response->body);
-    }
+    $this->http->get(uri: uri([TestController::class, 'basicRender']));
 
-    public function test_the_version_is_optional(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'basicRender']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-
-        $response->assertStatus(Status::OK);
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Edit', $page['component']);
-    }
-
-    public function test_the_version_can_be_a_number(): void
-    {
-        $version = 1597347897973;
-
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'numericVersion']),
-            headers: [
-                Header::INERTIA => 'true',
-                Header::VERSION => (string) $version,
-            ],
-        );
-
-        $page = $response->body;
-
-        $response->assertStatus(Status::OK);
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Edit', $page['component']);
-    }
-
-    public function test_the_version_can_be_a_string(): void
-    {
-        $version = 'foo-version';
-
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'stringVersion']),
-            headers: [
-                Header::INERTIA => 'true',
-                Header::VERSION => $version,
-            ],
-        );
-
-        $page = $response->body;
-
-        $response->assertStatus(Status::OK);
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Edit', $page['component']);
-    }
-
-    public function test_it_will_instruct_inertia_to_reload_on_a_version_mismatch(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'stringVersion']),
-            headers: [
-                Header::INERTIA => 'true',
-                Header::VERSION => 'a-different-version',
-            ],
-        );
-
-        $response->assertStatus(Status::CONFLICT);
-        $this->assertSame('/string-version-test', $response->headers[Header::LOCATION]->values[0]);
-        $this->assertEmpty($response->body);
-    }
-
-    public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-
-        $response->assertStatus(Status::OK);
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('/my-custom-url', $page['url']);
-    }
-
-    public function test_validation_errors_are_registered_as_of_default(): void
-    {
-        $middleware = $this->container->get(Middleware::class);
-        $request = $this->container->get(Request::class);
-        $this->assertInstanceOf(Middleware::class, $middleware);
-
-        $sharedData = $middleware->share($request);
-
-        $this->assertArrayHasKey('errors', $sharedData);
-        $this->assertInstanceOf(AlwaysProp::class, $sharedData['errors']);
-    }
-
-    public function test_validation_errors_can_be_empty(): void
-    {
-        $middleware = $this->container->get(Middleware::class);
-        $request = $this->container->get(Request::class);
-        $this->assertInstanceOf(Middleware::class, $middleware);
-
-        $sharedData = $middleware->share($request);
-        $errors = $sharedData['errors']();
-
-        $this->assertIsObject($errors);
-        $this->assertEmpty(get_object_vars($errors));
-    }
-
-    public function test_validation_errors_are_returned_in_the_correct_format(): void
-    {
-        $session = $this->container->get(Session::class);
-
-        $validationErrors = [
-            'email' => [new Email()],
-        ];
-        $this->assertInstanceOf(Session::class, $session);
-        $session->set(Session::VALIDATION_ERRORS, $validationErrors);
-
-        $middleware = $this->container->get(Middleware::class);
-        $request = $this->container->get(Request::class);
-        $this->assertInstanceOf(Middleware::class, $middleware);
-
-        $sharedData = $middleware->share($request);
-        $errors = $sharedData['errors']();
-
-        $this->assertIsObject($errors);
-        $this->assertSame('Value should be a valid email address', $errors->email);
-    }
-
-    public function test_default_validation_errors_can_be_overwritten(): void
-    {
-        $session = $this->container->get(Session::class);
-        $this->assertInstanceOf(Session::class, $session);
-        $session->set(Session::VALIDATION_ERRORS, ['name' => ['This should be overwritten.']]);
-
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'overwriteErrorsProp']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertArrayHasKey('errors', $page['props']);
-        $this->assertSame('foo', $page['props']['errors']);
-    }
-
-    public function test_validation_errors_are_scoped_to_error_bag_header(): void
-    {
-        $session = $this->container->get(Session::class);
-
-        $validationErrors = [
-            'email' => [new Email()],
-        ];
-        $this->assertInstanceOf(Session::class, $session);
-        $session->set(Session::VALIDATION_ERRORS, $validationErrors);
-
-        $middleware = $this->container->get(Middleware::class);
-        $request = $this->makeRequest(headers: [Header::ERROR_BAG => 'example']);
-        $this->assertInstanceOf(Middleware::class, $middleware);
-
-        $sharedData = $middleware->share($request);
-        $errors = $sharedData['errors']();
-
-        $this->assertIsObject($errors);
-        $this->assertObjectHasProperty('example', $errors);
-        $this->assertSame('Value should be a valid email address', $errors->example->email);
-    }
-
-    public function test_middleware_can_change_the_root_view_via_a_property(): void
-    {
-        $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']));
-
-        $response->assertStatus(Status::OK);
-        $this->assertInstanceOf(InertiaView::class, $response->body);
-        $this->assertSame('welcome', $response->body->path);
-    }
-
-    public function test_middleware_can_change_the_root_view_by_overriding_the_rootview_method(): void
-    {
-        $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']));
-
-        $response->assertStatus(Status::OK);
-        $this->assertInstanceOf(InertiaView::class, $response->body);
-        $this->assertSame('welcome', $response->body->path);
-    }
-
-    public function test_determine_the_version_by_a_hash_of_the_asset_url(): void
-    {
-        $url = 'https://example.com/assets';
-        $originalEnv = getenv('VITE_ASSET_URL');
-        putenv("VITE_ASSET_URL={$url}");
-
-        try {
-            $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
-
-            $page = $response->body->inertia['page'];
-
-            $response->assertStatus(Status::OK);
-            $this->assertInstanceOf(InertiaView::class, $response->body);
-            $this->assertSame(hash('xxh128', $url), $page['version']);
-        } finally {
-            if ($originalEnv === false) {
-                putenv('VITE_ASSET_URL');
-            } else {
-                putenv("VITE_ASSET_URL={$originalEnv}");
-            }
-        }
-    }
-
-    public function test_determine_the_version_by_a_hash_of_the_vite_manifest(): void
-    {
-        $manifestPath = root_path('public/build/manifest.json');
-        $directoryPath = dirname($manifestPath);
-        $contents = json_encode(['vite' => true]);
-
-        if (!is_dir($directoryPath)) {
-            mkdir($directoryPath, 0o777, true);
-        }
-
-        file_put_contents($manifestPath, $contents);
-
-        try {
-            $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
-
-            $page = $response->body->inertia['page'];
-
-            $response->assertStatus(Status::OK);
-            $this->assertInstanceOf(InertiaView::class, $response->body);
-            $this->assertSame(hash_file('xxh128', $manifestPath), $page['version']);
-        } finally {
-            unlink($manifestPath);
-            rmdir($directoryPath);
-        }
-    }
-
-    public function test_determine_the_version_by_a_hash_of_the_vite_manifest_from_env_path(): void
-    {
-        $manifestPath = root_path('temp-manifest.json');
-        $manifestContents = json_encode(['vite' => true]);
-        file_put_contents($manifestPath, $manifestContents);
-
-        $originalEnv = getenv('TEMPEST_PLUGIN_CONFIGURATION_PATH');
-        putenv("TEMPEST_PLUGIN_CONFIGURATION_PATH={$manifestPath}");
-
-        $kernel = FrameworkKernel::boot($this->root, discoveryLocations: $this->discoveryLocations);
-        $http = new HttpRouterTester($kernel->container);
-
-        try {
-            $response = $http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']));
-            $page = $response->body->inertia['page'];
-
-            $response->assertStatus(Status::OK);
-            $this->assertInstanceOf(InertiaView::class, $response->body);
-            $this->assertSame(hash_file('xxh128', $manifestPath), $page['version']);
-        } finally {
-            unlink($manifestPath);
-            if ($originalEnv === false) {
-                putenv('TEMPEST_PLUGIN_CONFIGURATION_PATH');
-            } else {
-                putenv("TEMPEST_PLUGIN_CONFIGURATION_PATH={$originalEnv}");
-            }
-        }
-    }
-
-    public function test_extended_middleware_only_runs_once(): void
-    {
-        $this->container->singleton(Middleware::class, fn() => $this->container->get(ExampleMiddleware::class));
-
-        $this->http->get(uri: uri([TestController::class, 'basicRender']));
-
-        $this->assertSame(1, ExampleMiddleware::$runCount);
-    }
+    $this->assertSame(1, ExampleMiddleware::$runCount);
+  }
 }

--- a/tests/Integration/ResponseFactoryTest.php
+++ b/tests/Integration/ResponseFactoryTest.php
@@ -22,403 +22,403 @@ use function Tempest\Router\uri;
 
 class ResponseFactoryTest extends TestCase
 {
-  public function test_location_response_for_inertia_requests(): void
-  {
-    $this->makeRequest(
-      uri: '/',
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $response = $this->factory->location('https://inertiajs.com');
-
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertSame(Status::CONFLICT, $response->status);
-    $this->assertSame('https://inertiajs.com', $response->getHeader(Header::LOCATION)->values[0]);
-  }
-
-  public function test_location_response_for_non_inertia_requests(): void
-  {
-    $response = $this->factory->location('https://inertiajs.com');
-
-    $this->assertInstanceOf(Redirect::class, $response);
-    $this->assertSame(Status::FOUND, $response->status);
-    $this->assertSame('https://inertiajs.com', $response->getHeader('Location')->values[0]);
-  }
-
-  public function test_location_response_for_inertia_requests_using_redirect_response(): void
-  {
-    $this->makeRequest(
-      uri: '/',
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $redirect = new Redirect('https://inertiajs.com');
-
-    $response = $this->factory->location($redirect);
-
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertSame(Status::CONFLICT, $response->status);
-    $this->assertSame('https://inertiajs.com', $response->getHeader(Header::LOCATION)->values[0]);
-  }
-
-  public function test_location_response_for_non_inertia_requests_using_redirect_response(): void
-  {
-    $redirect = new Redirect('https://inertiajs.com');
-
-    $response = $this->factory->location($redirect);
-
-    $this->assertSame($redirect, $response);
-  }
-
-  public function test_location_redirects_are_not_modified(): void
-  {
-    $response = $this->factory->location('/foo');
-
-    $this->assertInstanceOf(Redirect::class, $response);
-    $this->assertSame(Status::FOUND, $response->status);
-    $this->assertSame('/foo', $response->getHeader('Location')->values[0]);
-  }
-
-  public function test_location_response_for_non_inertia_requests_using_redirect_response_with_existing_session_and_request_properties(): void
-  {
-    $redirect = new Redirect('https://inertiajs.com');
-
-    $redirect->addSession('test_key', 'test_value');
-
-    $response = $this->factory->location($redirect);
-
-    $this->assertInstanceOf(Redirect::class, $response);
-    $this->assertSame(Status::FOUND, $response->status);
-    $this->assertSame('https://inertiajs.com', $response->getHeader('Location')->values[0]);
-    $this->assertSame('test_value', $response->session->get('test_key'));
-    $this->assertSame($redirect, $response);
-  }
-
-  public function test_the_version_can_be_a_closure(): void
-  {
-    $expectedVersion = 'test-version-from-closure';
-
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'versionCanBeAClosure']),
-      headers: [
-        Header::INERTIA => 'true',
-        Header::VERSION => $expectedVersion,
-      ],
-    );
-
-    $page = $response->body;
-
-    $response->assertStatus(Status::OK);
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $response->assertHasHeader(Header::INERTIA);
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('test-version-from-closure', $page['version']);
-    $this->assertSame('bar', $page['props']['foo']);
-  }
-
-  public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'customUrlResolver']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('/my-custom-url', $page['url']);
-  }
-
-  public function test_shared_data_can_be_shared_from_anywhere(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'sharedData']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertArrayHasKey('foo', $page['props']);
-    $this->assertSame('bar', $page['props']['foo']);
-  }
-
-  public function test_dot_props_are_merged_from_shared(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'dotPropMerging']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-    $props = $page['props'];
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $props['auth']['user']['name']);
-    $this->assertFalse($props['auth']['user']['can']['create_group']);
-  }
-
-  public function test_shared_data_can_resolve_closure_arguments(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'sharedClosure']).'?foo=bar',
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertArrayHasKey('query', $page['props']);
-    $this->assertSame(['foo' => 'bar'], $page['props']['query']);
-  }
-
-  public function test_dot_props_with_callbacks_are_merged_from_shared(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'dotPropsWithCallbacksMerging']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-    $props = $page['props'];
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $props['auth']['user']['name']);
-    $this->assertFalse($props['auth']['user']['can']['create_group']);
-  }
-
-  public function test_can_flush_shared_data(): void
-  {
-    inertia()->share('foo', 'bar');
-    $this->assertSame(['foo' => 'bar'], inertia()->getShared());
-    inertia()->flushShared();
-    $this->assertSame([], inertia()->getShared());
-  }
-
-  public function test_can_create_lazy_prop(): void
-  {
-    $this->expectUserDeprecationMessage('Method '.
-    ResponseFactory::class.
-        '::lazy() is deprecated, Use `optional` instead.');
-
-    $lazyProp = $this->factory->lazy(function () {
-      return 'A lazy value';
-    });
-
-    $this->assertInstanceOf(LazyProp::class, $lazyProp);
-  }
-
-  public function test_can_create_deferred_prop(): void
-  {
-    $deferredProp = $this->factory->defer(function () {
-      return 'A deferred value';
-    });
-
-    $this->assertInstanceOf(DeferProp::class, $deferredProp);
-    $this->assertSame('default', $deferredProp->group());
-  }
-
-  public function test_can_create_deferred_prop_with_custom_group(): void
-  {
-    $deferredProp = $this->factory->defer(function () {
-      return 'A deferred value';
-    }, 'foo');
-
-    $this->assertInstanceOf(DeferProp::class, $deferredProp);
-    $this->assertSame('foo', $deferredProp->group());
-  }
-
-  public function test_can_create_merged_prop(): void
-  {
-    $mergedProp = $this->factory->merge(function () {
-      return 'A merged value';
-    });
-
-    $this->assertInstanceOf(MergeProp::class, $mergedProp);
-  }
-
-  public function test_can_create_deep_merged_prop(): void
-  {
-    $mergedProp = $this->factory->deepMerge(function () {
-      return 'A merged value';
-    });
-
-    $this->assertInstanceOf(MergeProp::class, $mergedProp);
-  }
-
-  public function test_can_create_deferred_and_merged_prop(): void
-  {
-    $deferredProp = $this->factory->defer(function () {
-      return 'A deferred + merged value';
-    })->merge();
-
-    $this->assertInstanceOf(DeferProp::class, $deferredProp);
-  }
-
-  public function test_can_create_deferred_and_deep_merged_prop(): void
-  {
-    $deferredProp = $this->factory->defer(function () {
-      return 'A deferred + merged value';
-    })->deepMerge();
-
-    $this->assertInstanceOf(DeferProp::class, $deferredProp);
-  }
-
-  public function test_can_create_optional_prop(): void
-  {
-    $optionalProp = $this->factory->optional(function () {
-      return 'An optional value';
-    });
-
-    $this->assertInstanceOf(OptionalProp::class, $optionalProp);
-  }
-
-  public function test_can_create_always_prop(): void
-  {
-    $alwaysProp = $this->factory->always(function () {
-      return 'An always value';
-    });
-
-    $this->assertInstanceOf(AlwaysProp::class, $alwaysProp);
-  }
-
-  public function test_will_accept_arrayable_props(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'arrayableProps']),
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $page = $response->body;
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertArrayHasKey('foo', $page['props']);
-    $this->assertSame('bar', $page['props']['foo']);
-  }
-
-  public function test_will_accept_instances_of_provides_inertia_props(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'renderWithProvider']),
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $page = $response->body;
-    $props = $page['props'];
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertArrayHasKey('errors', $props);
-    $this->assertArrayHasKey('foo', $props);
-    $this->assertSame('bar', $props['foo']);
-    $this->assertCount(2, $props);
-  }
-
-  public function test_will_accept_arrays_containing_provides_inertia_props_in_render(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'renderWithMixedProps']),
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $page = $response->body;
-    $props = $page['props'];
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertArrayHasKey('errors', $props);
-    $this->assertArrayHasKey('regular', $props);
-    $this->assertArrayHasKey('from_object', $props);
-    $this->assertArrayHasKey('another', $props);
-    $this->assertSame('prop', $props['regular']);
-    $this->assertSame('value', $props['from_object']);
-    $this->assertSame('normal_prop', $props['another']);
-    $this->assertCount(4, $props);
-  }
-
-  public function test_can_share_instances_of_provides_inertia_props(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'shareWithProvider']),
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $page = $response->body;
-    $props = $page['props'];
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertArrayHasKey('errors', $props);
-    $this->assertArrayHasKey('shared', $props);
-    $this->assertArrayHasKey('regular', $props);
-    $this->assertSame('data', $props['shared']);
-    $this->assertSame('prop', $props['regular']);
-    $this->assertCount(3, $props);
-  }
-
-  public function test_can_share_arrays_containing_provides_inertia_props(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'shareWithMixedProps']),
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $page = $response->body;
-    $props = $page['props'];
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertArrayHasKey('errors', $props);
-    $this->assertArrayHasKey('regular', $props);
-    $this->assertArrayHasKey('from_object', $props);
-    $this->assertArrayHasKey('component', $props);
-    $this->assertSame('shared_prop', $props['regular']);
-    $this->assertSame('shared_value', $props['from_object']);
-    $this->assertSame('prop', $props['component']);
-    $this->assertCount(4, $props);
-  }
-
-  public function test_will_throw_exception_if_component_does_not_exist_when_ensuring_is_enabled(): void
-  {
-    $config = $this->container->get(InertiaConfig::class);
-
-    $originalValue = $config->pages->ensure_pages_exists;
-    $config->pages->ensure_pages_exists = true;
-
-    try {
-      $this->expectException(ComponentNotFoundException::class);
-      $this->expectExceptionMessage('Inertia page component [foo] not found.');
-
-      $this->factory->render('foo');
-    } finally {
-      $config->pages->ensure_pages_exists = $originalValue;
+    public function test_location_response_for_inertia_requests(): void
+    {
+        $this->makeRequest(
+            uri: '/',
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $response = $this->factory->location('https://inertiajs.com');
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(Status::CONFLICT, $response->status);
+        $this->assertSame('https://inertiajs.com', $response->getHeader(Header::LOCATION)->values[0]);
     }
-  }
 
-  public function test_will_not_throw_exception_if_component_does_not_exist_when_ensuring_is_disabled(): void
-  {
-    $originalEnv = getenv('INERTIA_ENSURE_PAGES_EXISTS');
-    putenv('INERTIA_ENSURE_PAGES_EXISTS=false');
+    public function test_location_response_for_non_inertia_requests(): void
+    {
+        $response = $this->factory->location('https://inertiajs.com');
 
-    try {
-      $response = $this->container->get(ResponseFactory::class)->render('foo');
-
-      $this->assertInstanceOf(Response::class, $response);
-    } finally {
-      if ($originalEnv === false) {
-        putenv('INERTIA_ENSURE_PAGES_EXISTS');
-      } else {
-        putenv("INERTIA_ENSURE_PAGES_EXISTS={$originalEnv}");
-      }
+        $this->assertInstanceOf(Redirect::class, $response);
+        $this->assertSame(Status::FOUND, $response->status);
+        $this->assertSame('https://inertiajs.com', $response->getHeader('Location')->values[0]);
     }
-  }
+
+    public function test_location_response_for_inertia_requests_using_redirect_response(): void
+    {
+        $this->makeRequest(
+            uri: '/',
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $redirect = new Redirect('https://inertiajs.com');
+
+        $response = $this->factory->location($redirect);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(Status::CONFLICT, $response->status);
+        $this->assertSame('https://inertiajs.com', $response->getHeader(Header::LOCATION)->values[0]);
+    }
+
+    public function test_location_response_for_non_inertia_requests_using_redirect_response(): void
+    {
+        $redirect = new Redirect('https://inertiajs.com');
+
+        $response = $this->factory->location($redirect);
+
+        $this->assertSame($redirect, $response);
+    }
+
+    public function test_location_redirects_are_not_modified(): void
+    {
+        $response = $this->factory->location('/foo');
+
+        $this->assertInstanceOf(Redirect::class, $response);
+        $this->assertSame(Status::FOUND, $response->status);
+        $this->assertSame('/foo', $response->getHeader('Location')->values[0]);
+    }
+
+    public function test_location_response_for_non_inertia_requests_using_redirect_response_with_existing_session_and_request_properties(): void
+    {
+        $redirect = new Redirect('https://inertiajs.com');
+
+        $redirect->addSession('test_key', 'test_value');
+
+        $response = $this->factory->location($redirect);
+
+        $this->assertInstanceOf(Redirect::class, $response);
+        $this->assertSame(Status::FOUND, $response->status);
+        $this->assertSame('https://inertiajs.com', $response->getHeader('Location')->values[0]);
+        $this->assertSame('test_value', $response->session->get('test_key'));
+        $this->assertSame($redirect, $response);
+    }
+
+    public function test_the_version_can_be_a_closure(): void
+    {
+        $expectedVersion = 'test-version-from-closure';
+
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'versionCanBeAClosure']),
+            headers: [
+                Header::INERTIA => 'true',
+                Header::VERSION => $expectedVersion,
+            ],
+        );
+
+        $page = $response->body;
+
+        $response->assertStatus(Status::OK);
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $response->assertHasHeader(Header::INERTIA);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('test-version-from-closure', $page['version']);
+        $this->assertSame('bar', $page['props']['foo']);
+    }
+
+    public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'customUrlResolver']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('/my-custom-url', $page['url']);
+    }
+
+    public function test_shared_data_can_be_shared_from_anywhere(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'sharedData']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayHasKey('foo', $page['props']);
+        $this->assertSame('bar', $page['props']['foo']);
+    }
+
+    public function test_dot_props_are_merged_from_shared(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'dotPropMerging']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+        $props = $page['props'];
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $props['auth']['user']['name']);
+        $this->assertFalse($props['auth']['user']['can']['create_group']);
+    }
+
+    public function test_shared_data_can_resolve_closure_arguments(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'sharedClosure']) . '?foo=bar',
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayHasKey('query', $page['props']);
+        $this->assertSame(['foo' => 'bar'], $page['props']['query']);
+    }
+
+    public function test_dot_props_with_callbacks_are_merged_from_shared(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'dotPropsWithCallbacksMerging']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+        $props = $page['props'];
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $props['auth']['user']['name']);
+        $this->assertFalse($props['auth']['user']['can']['create_group']);
+    }
+
+    public function test_can_flush_shared_data(): void
+    {
+        inertia()->share('foo', 'bar');
+        $this->assertSame(['foo' => 'bar'], inertia()->getShared());
+        inertia()->flushShared();
+        $this->assertSame([], inertia()->getShared());
+    }
+
+    public function test_can_create_lazy_prop(): void
+    {
+        $this->expectUserDeprecationMessage('Method ' .
+        ResponseFactory::class .
+            '::lazy() is deprecated, Use `optional` instead.');
+
+        $lazyProp = $this->factory->lazy(function () {
+            return 'A lazy value';
+        });
+
+        $this->assertInstanceOf(LazyProp::class, $lazyProp);
+    }
+
+    public function test_can_create_deferred_prop(): void
+    {
+        $deferredProp = $this->factory->defer(function () {
+            return 'A deferred value';
+        });
+
+        $this->assertInstanceOf(DeferProp::class, $deferredProp);
+        $this->assertSame('default', $deferredProp->group());
+    }
+
+    public function test_can_create_deferred_prop_with_custom_group(): void
+    {
+        $deferredProp = $this->factory->defer(function () {
+            return 'A deferred value';
+        }, 'foo');
+
+        $this->assertInstanceOf(DeferProp::class, $deferredProp);
+        $this->assertSame('foo', $deferredProp->group());
+    }
+
+    public function test_can_create_merged_prop(): void
+    {
+        $mergedProp = $this->factory->merge(function () {
+            return 'A merged value';
+        });
+
+        $this->assertInstanceOf(MergeProp::class, $mergedProp);
+    }
+
+    public function test_can_create_deep_merged_prop(): void
+    {
+        $mergedProp = $this->factory->deepMerge(function () {
+            return 'A merged value';
+        });
+
+        $this->assertInstanceOf(MergeProp::class, $mergedProp);
+    }
+
+    public function test_can_create_deferred_and_merged_prop(): void
+    {
+        $deferredProp = $this->factory->defer(function () {
+            return 'A deferred + merged value';
+        })->merge();
+
+        $this->assertInstanceOf(DeferProp::class, $deferredProp);
+    }
+
+    public function test_can_create_deferred_and_deep_merged_prop(): void
+    {
+        $deferredProp = $this->factory->defer(function () {
+            return 'A deferred + merged value';
+        })->deepMerge();
+
+        $this->assertInstanceOf(DeferProp::class, $deferredProp);
+    }
+
+    public function test_can_create_optional_prop(): void
+    {
+        $optionalProp = $this->factory->optional(function () {
+            return 'An optional value';
+        });
+
+        $this->assertInstanceOf(OptionalProp::class, $optionalProp);
+    }
+
+    public function test_can_create_always_prop(): void
+    {
+        $alwaysProp = $this->factory->always(function () {
+            return 'An always value';
+        });
+
+        $this->assertInstanceOf(AlwaysProp::class, $alwaysProp);
+    }
+
+    public function test_will_accept_arrayable_props(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'arrayableProps']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $page = $response->body;
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayHasKey('foo', $page['props']);
+        $this->assertSame('bar', $page['props']['foo']);
+    }
+
+    public function test_will_accept_instances_of_provides_inertia_props(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'renderWithProvider']),
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $page = $response->body;
+        $props = $page['props'];
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayHasKey('errors', $props);
+        $this->assertArrayHasKey('foo', $props);
+        $this->assertSame('bar', $props['foo']);
+        $this->assertCount(2, $props);
+    }
+
+    public function test_will_accept_arrays_containing_provides_inertia_props_in_render(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'renderWithMixedProps']),
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $page = $response->body;
+        $props = $page['props'];
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayHasKey('errors', $props);
+        $this->assertArrayHasKey('regular', $props);
+        $this->assertArrayHasKey('from_object', $props);
+        $this->assertArrayHasKey('another', $props);
+        $this->assertSame('prop', $props['regular']);
+        $this->assertSame('value', $props['from_object']);
+        $this->assertSame('normal_prop', $props['another']);
+        $this->assertCount(4, $props);
+    }
+
+    public function test_can_share_instances_of_provides_inertia_props(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'shareWithProvider']),
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $page = $response->body;
+        $props = $page['props'];
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayHasKey('errors', $props);
+        $this->assertArrayHasKey('shared', $props);
+        $this->assertArrayHasKey('regular', $props);
+        $this->assertSame('data', $props['shared']);
+        $this->assertSame('prop', $props['regular']);
+        $this->assertCount(3, $props);
+    }
+
+    public function test_can_share_arrays_containing_provides_inertia_props(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'shareWithMixedProps']),
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $page = $response->body;
+        $props = $page['props'];
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayHasKey('errors', $props);
+        $this->assertArrayHasKey('regular', $props);
+        $this->assertArrayHasKey('from_object', $props);
+        $this->assertArrayHasKey('component', $props);
+        $this->assertSame('shared_prop', $props['regular']);
+        $this->assertSame('shared_value', $props['from_object']);
+        $this->assertSame('prop', $props['component']);
+        $this->assertCount(4, $props);
+    }
+
+    public function test_will_throw_exception_if_component_does_not_exist_when_ensuring_is_enabled(): void
+    {
+        $config = $this->container->get(InertiaConfig::class);
+
+        $originalValue = $config->pages->ensure_pages_exists;
+        $config->pages->ensure_pages_exists = true;
+
+        try {
+            $this->expectException(ComponentNotFoundException::class);
+            $this->expectExceptionMessage('Inertia page component [foo] not found.');
+
+            $this->factory->render('foo');
+        } finally {
+            $config->pages->ensure_pages_exists = $originalValue;
+        }
+    }
+
+    public function test_will_not_throw_exception_if_component_does_not_exist_when_ensuring_is_disabled(): void
+    {
+        $originalEnv = getenv('INERTIA_ENSURE_PAGES_EXISTS');
+        putenv('INERTIA_ENSURE_PAGES_EXISTS=false');
+
+        try {
+            $response = $this->container->get(ResponseFactory::class)->render('foo');
+
+            $this->assertInstanceOf(Response::class, $response);
+        } finally {
+            if ($originalEnv === false) {
+                putenv('INERTIA_ENSURE_PAGES_EXISTS');
+            } else {
+                putenv("INERTIA_ENSURE_PAGES_EXISTS={$originalEnv}");
+            }
+        }
+    }
 }

--- a/tests/Integration/ResponseFactoryTest.php
+++ b/tests/Integration/ResponseFactoryTest.php
@@ -18,407 +18,407 @@ use Tempest\Http\Response;
 use Tempest\Http\Responses\Redirect;
 use Tempest\Http\Status;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 class ResponseFactoryTest extends TestCase
 {
-    public function test_location_response_for_inertia_requests(): void
-    {
-        $this->makeRequest(
-            uri: '/',
-            headers: [Header::INERTIA => 'true'],
-        );
+  public function test_location_response_for_inertia_requests(): void
+  {
+    $this->makeRequest(
+      uri: '/',
+      headers: [Header::INERTIA => 'true'],
+    );
 
-        $response = $this->factory->location('https://inertiajs.com');
+    $response = $this->factory->location('https://inertiajs.com');
 
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertSame(Status::CONFLICT, $response->status);
-        $this->assertSame('https://inertiajs.com', $response->getHeader(Header::LOCATION)->values[0]);
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertSame(Status::CONFLICT, $response->status);
+    $this->assertSame('https://inertiajs.com', $response->getHeader(Header::LOCATION)->values[0]);
+  }
+
+  public function test_location_response_for_non_inertia_requests(): void
+  {
+    $response = $this->factory->location('https://inertiajs.com');
+
+    $this->assertInstanceOf(Redirect::class, $response);
+    $this->assertSame(Status::FOUND, $response->status);
+    $this->assertSame('https://inertiajs.com', $response->getHeader('Location')->values[0]);
+  }
+
+  public function test_location_response_for_inertia_requests_using_redirect_response(): void
+  {
+    $this->makeRequest(
+      uri: '/',
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $redirect = new Redirect('https://inertiajs.com');
+
+    $response = $this->factory->location($redirect);
+
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertSame(Status::CONFLICT, $response->status);
+    $this->assertSame('https://inertiajs.com', $response->getHeader(Header::LOCATION)->values[0]);
+  }
+
+  public function test_location_response_for_non_inertia_requests_using_redirect_response(): void
+  {
+    $redirect = new Redirect('https://inertiajs.com');
+
+    $response = $this->factory->location($redirect);
+
+    $this->assertSame($redirect, $response);
+  }
+
+  public function test_location_redirects_are_not_modified(): void
+  {
+    $response = $this->factory->location('/foo');
+
+    $this->assertInstanceOf(Redirect::class, $response);
+    $this->assertSame(Status::FOUND, $response->status);
+    $this->assertSame('/foo', $response->getHeader('Location')->values[0]);
+  }
+
+  public function test_location_response_for_non_inertia_requests_using_redirect_response_with_existing_session_and_request_properties(): void
+  {
+    $redirect = new Redirect('https://inertiajs.com');
+
+    $redirect->addSession('test_key', 'test_value');
+
+    $response = $this->factory->location($redirect);
+
+    $this->assertInstanceOf(Redirect::class, $response);
+    $this->assertSame(Status::FOUND, $response->status);
+    $this->assertSame('https://inertiajs.com', $response->getHeader('Location')->values[0]);
+    $this->assertSame('test_value', $response->session->get('test_key'));
+    $this->assertSame($redirect, $response);
+  }
+
+  public function test_the_version_can_be_a_closure(): void
+  {
+    $expectedVersion = 'test-version-from-closure';
+
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'versionCanBeAClosure']),
+      headers: [
+        Header::INERTIA => 'true',
+        Header::VERSION => $expectedVersion,
+      ],
+    );
+
+    $page = $response->body;
+
+    $response->assertStatus(Status::OK);
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $response->assertHasHeader(Header::INERTIA);
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('test-version-from-closure', $page['version']);
+    $this->assertSame('bar', $page['props']['foo']);
+  }
+
+  public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'customUrlResolver']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('/my-custom-url', $page['url']);
+  }
+
+  public function test_shared_data_can_be_shared_from_anywhere(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'sharedData']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertArrayHasKey('foo', $page['props']);
+    $this->assertSame('bar', $page['props']['foo']);
+  }
+
+  public function test_dot_props_are_merged_from_shared(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'dotPropMerging']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+    $props = $page['props'];
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $props['auth']['user']['name']);
+    $this->assertFalse($props['auth']['user']['can']['create_group']);
+  }
+
+  public function test_shared_data_can_resolve_closure_arguments(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'sharedClosure']).'?foo=bar',
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertArrayHasKey('query', $page['props']);
+    $this->assertSame(['foo' => 'bar'], $page['props']['query']);
+  }
+
+  public function test_dot_props_with_callbacks_are_merged_from_shared(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'dotPropsWithCallbacksMerging']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+    $props = $page['props'];
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $props['auth']['user']['name']);
+    $this->assertFalse($props['auth']['user']['can']['create_group']);
+  }
+
+  public function test_can_flush_shared_data(): void
+  {
+    inertia()->share('foo', 'bar');
+    $this->assertSame(['foo' => 'bar'], inertia()->getShared());
+    inertia()->flushShared();
+    $this->assertSame([], inertia()->getShared());
+  }
+
+  public function test_can_create_lazy_prop(): void
+  {
+    $this->expectUserDeprecationMessage('Method '.
+    ResponseFactory::class.
+        '::lazy() is deprecated, Use `optional` instead.');
+
+    $lazyProp = $this->factory->lazy(function () {
+      return 'A lazy value';
+    });
+
+    $this->assertInstanceOf(LazyProp::class, $lazyProp);
+  }
+
+  public function test_can_create_deferred_prop(): void
+  {
+    $deferredProp = $this->factory->defer(function () {
+      return 'A deferred value';
+    });
+
+    $this->assertInstanceOf(DeferProp::class, $deferredProp);
+    $this->assertSame('default', $deferredProp->group());
+  }
+
+  public function test_can_create_deferred_prop_with_custom_group(): void
+  {
+    $deferredProp = $this->factory->defer(function () {
+      return 'A deferred value';
+    }, 'foo');
+
+    $this->assertInstanceOf(DeferProp::class, $deferredProp);
+    $this->assertSame('foo', $deferredProp->group());
+  }
+
+  public function test_can_create_merged_prop(): void
+  {
+    $mergedProp = $this->factory->merge(function () {
+      return 'A merged value';
+    });
+
+    $this->assertInstanceOf(MergeProp::class, $mergedProp);
+  }
+
+  public function test_can_create_deep_merged_prop(): void
+  {
+    $mergedProp = $this->factory->deepMerge(function () {
+      return 'A merged value';
+    });
+
+    $this->assertInstanceOf(MergeProp::class, $mergedProp);
+  }
+
+  public function test_can_create_deferred_and_merged_prop(): void
+  {
+    $deferredProp = $this->factory->defer(function () {
+      return 'A deferred + merged value';
+    })->merge();
+
+    $this->assertInstanceOf(DeferProp::class, $deferredProp);
+  }
+
+  public function test_can_create_deferred_and_deep_merged_prop(): void
+  {
+    $deferredProp = $this->factory->defer(function () {
+      return 'A deferred + merged value';
+    })->deepMerge();
+
+    $this->assertInstanceOf(DeferProp::class, $deferredProp);
+  }
+
+  public function test_can_create_optional_prop(): void
+  {
+    $optionalProp = $this->factory->optional(function () {
+      return 'An optional value';
+    });
+
+    $this->assertInstanceOf(OptionalProp::class, $optionalProp);
+  }
+
+  public function test_can_create_always_prop(): void
+  {
+    $alwaysProp = $this->factory->always(function () {
+      return 'An always value';
+    });
+
+    $this->assertInstanceOf(AlwaysProp::class, $alwaysProp);
+  }
+
+  public function test_will_accept_arrayable_props(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'arrayableProps']),
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $page = $response->body;
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertArrayHasKey('foo', $page['props']);
+    $this->assertSame('bar', $page['props']['foo']);
+  }
+
+  public function test_will_accept_instances_of_provides_inertia_props(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'renderWithProvider']),
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $page = $response->body;
+    $props = $page['props'];
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertArrayHasKey('errors', $props);
+    $this->assertArrayHasKey('foo', $props);
+    $this->assertSame('bar', $props['foo']);
+    $this->assertCount(2, $props);
+  }
+
+  public function test_will_accept_arrays_containing_provides_inertia_props_in_render(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'renderWithMixedProps']),
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $page = $response->body;
+    $props = $page['props'];
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertArrayHasKey('errors', $props);
+    $this->assertArrayHasKey('regular', $props);
+    $this->assertArrayHasKey('from_object', $props);
+    $this->assertArrayHasKey('another', $props);
+    $this->assertSame('prop', $props['regular']);
+    $this->assertSame('value', $props['from_object']);
+    $this->assertSame('normal_prop', $props['another']);
+    $this->assertCount(4, $props);
+  }
+
+  public function test_can_share_instances_of_provides_inertia_props(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'shareWithProvider']),
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $page = $response->body;
+    $props = $page['props'];
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertArrayHasKey('errors', $props);
+    $this->assertArrayHasKey('shared', $props);
+    $this->assertArrayHasKey('regular', $props);
+    $this->assertSame('data', $props['shared']);
+    $this->assertSame('prop', $props['regular']);
+    $this->assertCount(3, $props);
+  }
+
+  public function test_can_share_arrays_containing_provides_inertia_props(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'shareWithMixedProps']),
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $page = $response->body;
+    $props = $page['props'];
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertArrayHasKey('errors', $props);
+    $this->assertArrayHasKey('regular', $props);
+    $this->assertArrayHasKey('from_object', $props);
+    $this->assertArrayHasKey('component', $props);
+    $this->assertSame('shared_prop', $props['regular']);
+    $this->assertSame('shared_value', $props['from_object']);
+    $this->assertSame('prop', $props['component']);
+    $this->assertCount(4, $props);
+  }
+
+  public function test_will_throw_exception_if_component_does_not_exist_when_ensuring_is_enabled(): void
+  {
+    $config = $this->container->get(InertiaConfig::class);
+
+    $originalValue = $config->pages->ensure_pages_exists;
+    $config->pages->ensure_pages_exists = true;
+
+    try {
+      $this->expectException(ComponentNotFoundException::class);
+      $this->expectExceptionMessage('Inertia page component [foo] not found.');
+
+      $this->factory->render('foo');
+    } finally {
+      $config->pages->ensure_pages_exists = $originalValue;
     }
+  }
 
-    public function test_location_response_for_non_inertia_requests(): void
-    {
-        $response = $this->factory->location('https://inertiajs.com');
+  public function test_will_not_throw_exception_if_component_does_not_exist_when_ensuring_is_disabled(): void
+  {
+    $originalEnv = getenv('INERTIA_ENSURE_PAGES_EXISTS');
+    putenv('INERTIA_ENSURE_PAGES_EXISTS=false');
 
-        $this->assertInstanceOf(Redirect::class, $response);
-        $this->assertSame(Status::FOUND, $response->status);
-        $this->assertSame('https://inertiajs.com', $response->getHeader('Location')->values[0]);
+    try {
+      $response = $this->container->get(ResponseFactory::class)->render('foo');
+
+      $this->assertInstanceOf(Response::class, $response);
+    } finally {
+      if ($originalEnv === false) {
+        putenv('INERTIA_ENSURE_PAGES_EXISTS');
+      } else {
+        putenv("INERTIA_ENSURE_PAGES_EXISTS={$originalEnv}");
+      }
     }
-
-    public function test_location_response_for_inertia_requests_using_redirect_response(): void
-    {
-        $this->makeRequest(
-            uri: '/',
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $redirect = new Redirect('https://inertiajs.com');
-
-        $response = $this->factory->location($redirect);
-
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertSame(Status::CONFLICT, $response->status);
-        $this->assertSame('https://inertiajs.com', $response->getHeader(Header::LOCATION)->values[0]);
-    }
-
-    public function test_location_response_for_non_inertia_requests_using_redirect_response(): void
-    {
-        $redirect = new Redirect('https://inertiajs.com');
-
-        $response = $this->factory->location($redirect);
-
-        $this->assertSame($redirect, $response);
-    }
-
-    public function test_location_redirects_are_not_modified(): void
-    {
-        $response = $this->factory->location('/foo');
-
-        $this->assertInstanceOf(Redirect::class, $response);
-        $this->assertSame(Status::FOUND, $response->status);
-        $this->assertSame('/foo', $response->getHeader('Location')->values[0]);
-    }
-
-    public function test_location_response_for_non_inertia_requests_using_redirect_response_with_existing_session_and_request_properties(): void
-    {
-        $redirect = new Redirect('https://inertiajs.com');
-
-        $redirect->addSession('test_key', 'test_value');
-
-        $response = $this->factory->location($redirect);
-
-        $this->assertInstanceOf(Redirect::class, $response);
-        $this->assertSame(Status::FOUND, $response->status);
-        $this->assertSame('https://inertiajs.com', $response->getHeader('Location')->values[0]);
-        $this->assertSame('test_value', $response->session->get('test_key'));
-        $this->assertSame($redirect, $response);
-    }
-
-    public function test_the_version_can_be_a_closure(): void
-    {
-        $expectedVersion = 'test-version-from-closure';
-
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'versionCanBeAClosure']),
-            headers: [
-                Header::INERTIA => 'true',
-                Header::VERSION => $expectedVersion,
-            ],
-        );
-
-        $page = $response->body;
-
-        $response->assertStatus(Status::OK);
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $response->assertHasHeader(Header::INERTIA);
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('test-version-from-closure', $page['version']);
-        $this->assertSame('bar', $page['props']['foo']);
-    }
-
-    public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'customUrlResolver']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('/my-custom-url', $page['url']);
-    }
-
-    public function test_shared_data_can_be_shared_from_anywhere(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'sharedData']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertArrayHasKey('foo', $page['props']);
-        $this->assertSame('bar', $page['props']['foo']);
-    }
-
-    public function test_dot_props_are_merged_from_shared(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'dotPropMerging']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-        $props = $page['props'];
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $props['auth']['user']['name']);
-        $this->assertFalse($props['auth']['user']['can']['create_group']);
-    }
-
-    public function test_shared_data_can_resolve_closure_arguments(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'sharedClosure']) . '?foo=bar',
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertArrayHasKey('query', $page['props']);
-        $this->assertSame(['foo' => 'bar'], $page['props']['query']);
-    }
-
-    public function test_dot_props_with_callbacks_are_merged_from_shared(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'dotPropsWithCallbacksMerging']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-        $props = $page['props'];
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $props['auth']['user']['name']);
-        $this->assertFalse($props['auth']['user']['can']['create_group']);
-    }
-
-    public function test_can_flush_shared_data(): void
-    {
-        inertia()->share('foo', 'bar');
-        $this->assertSame(['foo' => 'bar'], inertia()->getShared());
-        inertia()->flushShared();
-        $this->assertSame([], inertia()->getShared());
-    }
-
-    public function test_can_create_lazy_prop(): void
-    {
-        $this->expectUserDeprecationMessage('Method ' .
-        ResponseFactory::class .
-            '::lazy() is deprecated, Use `optional` instead.');
-
-        $lazyProp = $this->factory->lazy(function () {
-            return 'A lazy value';
-        });
-
-        $this->assertInstanceOf(LazyProp::class, $lazyProp);
-    }
-
-    public function test_can_create_deferred_prop(): void
-    {
-        $deferredProp = $this->factory->defer(function () {
-            return 'A deferred value';
-        });
-
-        $this->assertInstanceOf(DeferProp::class, $deferredProp);
-        $this->assertSame('default', $deferredProp->group());
-    }
-
-    public function test_can_create_deferred_prop_with_custom_group(): void
-    {
-        $deferredProp = $this->factory->defer(function () {
-            return 'A deferred value';
-        }, 'foo');
-
-        $this->assertInstanceOf(DeferProp::class, $deferredProp);
-        $this->assertSame('foo', $deferredProp->group());
-    }
-
-    public function test_can_create_merged_prop(): void
-    {
-        $mergedProp = $this->factory->merge(function () {
-            return 'A merged value';
-        });
-
-        $this->assertInstanceOf(MergeProp::class, $mergedProp);
-    }
-
-    public function test_can_create_deep_merged_prop(): void
-    {
-        $mergedProp = $this->factory->deepMerge(function () {
-            return 'A merged value';
-        });
-
-        $this->assertInstanceOf(MergeProp::class, $mergedProp);
-    }
-
-    public function test_can_create_deferred_and_merged_prop(): void
-    {
-        $deferredProp = $this->factory->defer(function () {
-            return 'A deferred + merged value';
-        })->merge();
-
-        $this->assertInstanceOf(DeferProp::class, $deferredProp);
-    }
-
-    public function test_can_create_deferred_and_deep_merged_prop(): void
-    {
-        $deferredProp = $this->factory->defer(function () {
-            return 'A deferred + merged value';
-        })->deepMerge();
-
-        $this->assertInstanceOf(DeferProp::class, $deferredProp);
-    }
-
-    public function test_can_create_optional_prop(): void
-    {
-        $optionalProp = $this->factory->optional(function () {
-            return 'An optional value';
-        });
-
-        $this->assertInstanceOf(OptionalProp::class, $optionalProp);
-    }
-
-    public function test_can_create_always_prop(): void
-    {
-        $alwaysProp = $this->factory->always(function () {
-            return 'An always value';
-        });
-
-        $this->assertInstanceOf(AlwaysProp::class, $alwaysProp);
-    }
-
-    public function test_will_accept_arrayable_props(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'arrayableProps']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $page = $response->body;
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertArrayHasKey('foo', $page['props']);
-        $this->assertSame('bar', $page['props']['foo']);
-    }
-
-    public function test_will_accept_instances_of_provides_inertia_props(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'renderWithProvider']),
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $page = $response->body;
-        $props = $page['props'];
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertArrayHasKey('errors', $props);
-        $this->assertArrayHasKey('foo', $props);
-        $this->assertSame('bar', $props['foo']);
-        $this->assertCount(2, $props);
-    }
-
-    public function test_will_accept_arrays_containing_provides_inertia_props_in_render(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'renderWithMixedProps']),
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $page = $response->body;
-        $props = $page['props'];
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertArrayHasKey('errors', $props);
-        $this->assertArrayHasKey('regular', $props);
-        $this->assertArrayHasKey('from_object', $props);
-        $this->assertArrayHasKey('another', $props);
-        $this->assertSame('prop', $props['regular']);
-        $this->assertSame('value', $props['from_object']);
-        $this->assertSame('normal_prop', $props['another']);
-        $this->assertCount(4, $props);
-    }
-
-    public function test_can_share_instances_of_provides_inertia_props(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'shareWithProvider']),
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $page = $response->body;
-        $props = $page['props'];
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertArrayHasKey('errors', $props);
-        $this->assertArrayHasKey('shared', $props);
-        $this->assertArrayHasKey('regular', $props);
-        $this->assertSame('data', $props['shared']);
-        $this->assertSame('prop', $props['regular']);
-        $this->assertCount(3, $props);
-    }
-
-    public function test_can_share_arrays_containing_provides_inertia_props(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'shareWithMixedProps']),
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $page = $response->body;
-        $props = $page['props'];
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertArrayHasKey('errors', $props);
-        $this->assertArrayHasKey('regular', $props);
-        $this->assertArrayHasKey('from_object', $props);
-        $this->assertArrayHasKey('component', $props);
-        $this->assertSame('shared_prop', $props['regular']);
-        $this->assertSame('shared_value', $props['from_object']);
-        $this->assertSame('prop', $props['component']);
-        $this->assertCount(4, $props);
-    }
-
-    public function test_will_throw_exception_if_component_does_not_exist_when_ensuring_is_enabled(): void
-    {
-        $config = $this->container->get(InertiaConfig::class);
-
-        $originalValue = $config->pages->ensure_pages_exists;
-        $config->pages->ensure_pages_exists = true;
-
-        try {
-            $this->expectException(ComponentNotFoundException::class);
-            $this->expectExceptionMessage('Inertia page component [foo] not found.');
-
-            $this->factory->render('foo');
-        } finally {
-            $config->pages->ensure_pages_exists = $originalValue;
-        }
-    }
-
-    public function test_will_not_throw_exception_if_component_does_not_exist_when_ensuring_is_disabled(): void
-    {
-        $originalEnv = getenv('INERTIA_ENSURE_PAGES_EXISTS');
-        putenv('INERTIA_ENSURE_PAGES_EXISTS=false');
-
-        try {
-            $response = $this->container->get(ResponseFactory::class)->render('foo');
-
-            $this->assertInstanceOf(Response::class, $response);
-        } finally {
-            if ($originalEnv === false) {
-                putenv('INERTIA_ENSURE_PAGES_EXISTS');
-            } else {
-                putenv("INERTIA_ENSURE_PAGES_EXISTS={$originalEnv}");
-            }
-        }
-    }
+  }
 }

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -19,1025 +19,1028 @@ use Tempest\Http\Response;
 use Tempest\Support\Paginator\Paginator;
 use Tempest\View\ViewRenderer;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 class ResponseTest extends TestCase
 {
-    public function test_server_response(): void
-    {
-        $this->makeRequest();
-        $this->factory->version('123');
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-        ]);
-
-        $this->assertInstanceOf(LazyBody::class, $response->body);
-
-        $resolvedBody = $response->body->jsonSerialize();
-
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-        $renderer = $this->container->get(ViewRenderer::class);
-        $page = $response->body->inertia['page'];
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-
-        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
-        $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-    }
-
-    public function test_server_response_with_deferred_prop(): void
-    {
-        $this->makeRequest();
-        $this->factory->version('123');
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-            'foo' => new DeferProp(fn() => 'bar'),
-        ]);
-
-        $this->assertInstanceOf(LazyBody::class, $response->body);
-
-        $resolvedBody = $response->body->jsonSerialize();
-
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-        $renderer = $this->container->get(ViewRenderer::class);
-        $page = $response->body->inertia['page'];
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-
-        $this->assertArrayNotHasKey('foo', $page['props']);
-        $this->assertSame(['default' => ['foo']], $page['deferredProps']);
-
-        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo"]}}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
-        $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-    }
-
-    public function test_server_response_with_deferred_prop_and_multiple_groups(): void
-    {
-        $this->makeRequest();
-        $this->factory->version('123');
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-            'foo' => new DeferProp(fn() => 'foo value'),
-            'bar' => new DeferProp(fn() => 'bar value'),
-            'baz' => new DeferProp(fn() => 'baz value', 'custom'),
-        ]);
-
-        $renderer = $this->container->get(ViewRenderer::class);
-        $page = $response->body->inertia['page'];
-        $resolvedBody = $response->body->jsonSerialize();
-
-        $this->assertInstanceOf(LazyBody::class, $response->body);
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-
-        $this->assertArrayNotHasKey('foo', $page['props']);
-        $this->assertArrayNotHasKey('bar', $page['props']);
-        $this->assertArrayNotHasKey('baz', $page['props']);
-        $this->assertSame([
-            'default' => ['foo', 'bar'],
-            'custom' => ['baz'],
-        ], $page['deferredProps']);
-
-        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo","bar"],"custom":["baz"]}}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
-        $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-    }
-
-    public function test_server_response_with_merge_props(): void
-    {
-        $this->makeRequest();
-        $this->factory->version('123');
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-            'foo' => new MergeProp('foo value'),
-            'bar' => new MergeProp('bar value'),
-        ]);
-
-        $renderer = $this->container->get(ViewRenderer::class);
-        $page = $response->body->inertia['page'];
-        $resolvedBody = $response->body->jsonSerialize();
-
-        $this->assertInstanceOf(LazyBody::class, $response->body);
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-
-        $this->assertSame('foo value', $page['props']['foo']);
-        $this->assertSame('bar value', $page['props']['bar']);
-        $this->assertSame(['foo', 'bar'], $page['mergeProps']);
-
-        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"]}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
-        $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-    }
-
-    public function test_server_response_with_deep_merge_props(): void
-    {
-        $this->makeRequest();
-        $this->factory->version('123');
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-            'foo' => new MergeProp('foo value')->deepMerge(),
-            'bar' => new MergeProp('bar value')->deepMerge(),
-        ]);
-
-        $renderer = $this->container->get(ViewRenderer::class);
-        $page = $response->body->inertia['page'];
-        $resolvedBody = $response->body->jsonSerialize();
-
-        $this->assertInstanceOf(LazyBody::class, $response->body);
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-
-        $this->assertSame('foo value', $page['props']['foo']);
-        $this->assertSame('bar value', $page['props']['bar']);
-        $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
-
-        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"]}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
-        $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-    }
-
-    public function test_server_response_with_merge_strategies(): void
-    {
-        $this->makeRequest();
-        $this->factory->version('123');
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-            'foo' => new MergeProp('foo value')
-                ->matchOn('foo-key')
-                ->deepMerge(),
-            'bar' => new MergeProp('bar value')
-                ->matchOn('bar-key')
-                ->deepMerge(),
-        ]);
-
-        $renderer = $this->container->get(ViewRenderer::class);
-        $page = $response->body->inertia['page'];
-        $resolvedBody = $response->body->jsonSerialize();
-
-        $this->assertInstanceOf(LazyBody::class, $response->body);
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-
-        $this->assertSame('foo value', $page['props']['foo']);
-        $this->assertSame('bar value', $page['props']['bar']);
-        $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
-        $this->assertSame(['foo.foo-key', 'bar.bar-key'], $page['matchPropsOn']);
-
-        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"matchPropsOn":["foo.foo-key","bar.bar-key"]}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
-        $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-    }
-
-    public function test_server_response_with_defer_and_merge_props(): void
-    {
-        $this->makeRequest();
-        $this->factory->version('123');
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-            'foo' => new DeferProp(fn() => 'foo value')->merge(),
-            'bar' => new MergeProp('bar value'),
-        ]);
-
-        $renderer = $this->container->get(ViewRenderer::class);
-        $page = $response->body->inertia['page'];
-        $resolvedBody = $response->body->jsonSerialize();
-
-        $this->assertInstanceOf(LazyBody::class, $response->body);
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-
-        $this->assertArrayNotHasKey('foo', $page['props']);
-        $this->assertSame('bar value', $page['props']['bar']);
-        $this->assertSame(['default' => ['foo']], $page['deferredProps']);
-        $this->assertSame(['foo', 'bar'], $page['mergeProps']);
-
-        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
-        $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-    }
-
-    public function test_server_response_with_defer_and_deep_merge_props(): void
-    {
-        $this->makeRequest();
-        $this->factory->version('123');
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-            'foo' => new DeferProp(fn() => 'foo value')->deepMerge(),
-            'bar' => new MergeProp('bar value')->deepMerge(),
-        ]);
-
-        $renderer = $this->container->get(ViewRenderer::class);
-        $page = $response->body->inertia['page'];
-        $resolvedBody = $response->body->jsonSerialize();
-
-        $this->assertInstanceOf(LazyBody::class, $response->body);
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-
-        $this->assertArrayNotHasKey('foo', $page['props']);
-        $this->assertSame('bar value', $page['props']['bar']);
-        $this->assertSame(['default' => ['foo']], $page['deferredProps']);
-        $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
-
-        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
-        $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-    }
-
-    public function test_exclude_merge_props_from_partial_only_response(): void
-    {
-        $this->makeRequest(headers: [
-            Header::INERTIA => 'true',
-            Header::PARTIAL_COMPONENT => 'User/Edit',
-            Header::PARTIAL_ONLY => 'user',
-        ]);
-        $this->factory->version('123');
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-            'foo' => new MergeProp('foo value'),
-            'bar' => new MergeProp('bar value'),
-        ]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-
-        $this->assertArrayHasKey('user', $page['props']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-
-        $this->assertArrayNotHasKey('foo', $page['props']);
-        $this->assertArrayNotHasKey('bar', $page['props']);
-        $this->assertArrayNotHasKey('mergeProps', $page);
-    }
-
-    public function test_exclude_merge_props_from_partial_except_response(): void
-    {
-        $this->makeRequest(headers: [
-            Header::INERTIA => 'true',
-            Header::PARTIAL_COMPONENT => 'User/Edit',
-            Header::PARTIAL_EXCEPT => 'foo',
-        ]);
-        $this->factory->version('123');
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-            'foo' => new MergeProp('foo value'),
-            'bar' => new MergeProp('bar value'),
-        ]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-
-        $this->assertArrayHasKey('user', $page['props']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertArrayHasKey('bar', $page['props']);
-        $this->assertSame('bar value', $page['props']['bar']);
-        $this->assertArrayNotHasKey('foo', $page['props']);
-        $this->assertSame(['bar'], $page['mergeProps']);
-    }
-
-    public function test_xhr_response(): void
-    {
-        $this->makeRequest(headers: [
-            Header::INERTIA => 'true',
-        ]);
-        $this->factory->version('123');
-
-        $user = (object) ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-        ]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']->name);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-    }
-
-    public function test_resource_response(): void
-    {
-        $this->makeRequest(headers: [
-            Header::INERTIA => 'true',
-        ]);
-        $this->factory->version('123');
-
-        $resource = new FakeResource(['name' => 'Jonathan']);
-        $response = $this->factory->render('User/Edit', ['user' => $resource]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-    }
-
-    public function test_lazy_callable_resource_response(): void
-    {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [Header::INERTIA => 'true'],
-        );
-        $this->factory->version('123');
-
-        $response = $this->factory->render('User/Index', [
-            'users' => fn() => [['name' => 'Jonathan']],
-            'organizations' => fn() => [['name' => 'Inertia']],
-        ]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Index', $page['component']);
-        $this->assertSame('/users', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertSame([['name' => 'Jonathan']], $page['props']['users']);
-        $this->assertSame([['name' => 'Inertia']], $page['props']['organizations']);
-    }
-
-    public function test_lazy_callable_resource_partial_response(): void
-    {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [
-                Header::INERTIA => 'true',
-                Header::PARTIAL_COMPONENT => 'User/Index',
-                Header::PARTIAL_ONLY => 'users',
-            ],
-        );
-        $this->factory->version('123');
-
-        $response = $this->factory->render('User/Index', [
-            'users' => fn() => [['name' => 'Jonathan']],
-            'organizations' => fn() => [['name' => 'Inertia']],
-        ]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Index', $page['component']);
-        $this->assertSame('/users', $page['url']);
-        $this->assertSame('123', $page['version']);
-
-        $this->assertArrayHasKey('users', $page['props']);
-        $this->assertSame([['name' => 'Jonathan']], $page['props']['users']);
-        $this->assertArrayNotHasKey('organizations', $page['props']);
-    }
-
-    public function test_lazy_resource_response(): void
-    {
-        $this->makeRequest(
-            uri: '/users?page=1',
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $users = [
-            ['name' => 'Jonathan'],
-            ['name' => 'Taylor'],
-            ['name' => 'Jeffrey'],
-        ];
-
-        $callable = static function () use ($users) {
-            $paginator = new Paginator(
-                totalItems: count($users),
-                itemsPerPage: 2,
-                currentPage: 1,
-            );
-            return $paginator->paginate(array_slice($users, 0, 2));
-        };
-
-        $this->factory->version('123');
-        $response = $this->factory->render('User/Index', ['users' => $callable]);
-
-        $page = $response->body;
-
-        $this->assertSame('User/Index', $page['component']);
-        $this->assertSame('/users?page=1', $page['url']);
-        $this->assertSame('123', $page['version']);
-
-        $paginatedUsers = $page['props']['users'];
-
-        $this->assertArrayHasKey('data', $paginatedUsers);
-        $this->assertArrayHasKey('links', $paginatedUsers);
-        $this->assertArrayHasKey('meta', $paginatedUsers);
-
-        $this->assertSame([['name' => 'Jonathan'], ['name' => 'Taylor']], $paginatedUsers['data']);
-        $this->assertSame('/users?page=2', $paginatedUsers['links']['next']);
-        $this->assertSame(1, $paginatedUsers['meta']['current_page']);
-        $this->assertSame(3, $paginatedUsers['meta']['total']);
-    }
-
-    public function test_nested_lazy_resource_response(): void
-    {
-        $this->makeRequest(
-            uri: '/users?page=1',
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $users = [
-            ['name' => 'Jonathan'],
-            ['name' => 'Taylor'],
-            ['name' => 'Jeffrey'],
-        ];
-
-        $callable = static function () use ($users) {
-            $paginator = new Paginator(
-                totalItems: count($users),
-                itemsPerPage: 2,
-                currentPage: 1,
-            );
-            return [
-                'users' => $paginator->paginate(array_slice($users, 0, 2)),
-            ];
-        };
-
-        $this->factory->version('123');
-        $response = $this->factory->render('User/Index', ['something' => $callable]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Index', $page['component']);
-        $this->assertSame('/users?page=1', $page['url']);
-        $this->assertSame('123', $page['version']);
-
-        $nestedUsers = $page['props']['something']['users'];
-
-        $this->assertArrayHasKey('data', $nestedUsers);
-        $this->assertArrayHasKey('links', $nestedUsers);
-        $this->assertArrayHasKey('meta', $nestedUsers);
-        $this->assertSame([['name' => 'Jonathan'], ['name' => 'Taylor']], $nestedUsers['data']);
-        $this->assertSame('/users?page=2', $nestedUsers['links']['next']);
-        $this->assertSame('/users', $nestedUsers['meta']['path']);
-    }
-
-    public function test_arrayable_prop_response(): void
-    {
-        $this->makeRequest(headers: [
-            Header::INERTIA => 'true',
-        ]);
-
-        $this->factory->version('123');
-        $resource = new FakeResource(['name' => 'Jonathan']);
-        $response = $this->factory->render('User/Edit', ['user' => $resource]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-    }
-
-    public function test_promise_props_are_resolved(): void
-    {
-        $this->makeRequest(headers: [Header::INERTIA => 'true']);
-
-        $user = (object) ['name' => 'Jonathan'];
-
-        $promise = Mockery::mock(PromiseInterface::class)
-            ->shouldReceive('wait')
-            ->once()
-            ->andReturn($user)
-            ->getMock();
-
-        $this->factory->version('123');
-        $response = $this->factory->render('User/Edit', ['user' => $promise]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']->name);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-    }
-
-    public function test_xhr_partial_response(): void
-    {
-        $this->makeRequest(headers: [
-            Header::INERTIA => 'true',
-            Header::PARTIAL_COMPONENT => 'User/Edit',
-            Header::PARTIAL_ONLY => 'partial',
-        ]);
-
-        $this->factory->version('123');
-        $response = $this->factory->render('User/Edit', [
-            'user' => (object) ['name' => 'Jonathan'],
-            'partial' => 'partial-data',
-        ]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-
-        $this->assertCount(1, $page['props']);
-        $this->assertArrayHasKey('partial', $page['props']);
-        $this->assertSame('partial-data', $page['props']['partial']);
-        $this->assertArrayNotHasKey('user', $page['props']);
-    }
-
-    public function test_exclude_props_from_partial_response(): void
-    {
-        $this->makeRequest(headers: [
-            Header::INERTIA => 'true',
-            Header::PARTIAL_COMPONENT => 'User/Edit',
-            Header::PARTIAL_EXCEPT => 'user',
-        ]);
-
-        $this->factory->version('123');
-        $response = $this->factory->render('User/Edit', [
-            'user' => (object) ['name' => 'Jonathan'],
-            'partial' => 'partial-data',
-        ]);
-
-        $page = $response->body->jsonSerialize();
-
-        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-
-        $this->assertCount(1, $page['props']);
-        $this->assertArrayHasKey('partial', $page['props']);
-        $this->assertSame('partial-data', $page['props']['partial']);
-        $this->assertArrayNotHasKey('user', $page['props']);
-    }
-
-    public function test_nested_partial_props(): void
-    {
-        $this->makeRequest(headers: [
-            Header::INERTIA => 'true',
-            Header::PARTIAL_COMPONENT => 'User/Edit',
-            Header::PARTIAL_ONLY => 'auth.user,auth.shared_value',
-        ]);
-
-        $props = [
-            'auth' => [
-                'user' => new LazyProp(fn() => [
-                    'name' => 'Jonathan Reinink',
-                    'email' => 'jonathan@example.com',
-                ]),
-                'shared_value' => 'value',
-                'value' => 'value',
-            ],
-            'shared' => [
-                'flash' => 'value',
-            ],
-        ];
-
-        $response = $this->factory->render('User/Edit', $props);
-        $page = $response->body;
-
-        $this->assertArrayNotHasKey('shared', $page['props']);
-        $this->assertArrayHasKey('auth', $page['props']);
-        $this->assertArrayNotHasKey('value', $page['props']['auth']);
-        $this->assertSame('Jonathan Reinink', $page['props']['auth']['user']['name']);
-        $this->assertSame('jonathan@example.com', $page['props']['auth']['user']['email']);
-        $this->assertSame('value', $page['props']['auth']['shared_value']);
-    }
-
-    public function test_exclude_nested_props_from_partial_response(): void
-    {
-        $this->makeRequest(headers: [
-            Header::INERTIA => 'true',
-            Header::PARTIAL_COMPONENT => 'User/Edit',
-            Header::PARTIAL_ONLY => 'auth',
-            Header::PARTIAL_EXCEPT => 'auth.user',
-        ]);
-
-        $props = [
-            'auth' => [
-                'user' => new LazyProp(fn() => [
-                    'name' => 'Jonathan Reinink',
-                    'email' => 'jonathan@example.com',
-                ]),
-                'shared_value' => 'value',
-            ],
-            'shared' => [
-                'flash' => 'value',
-            ],
-        ];
-
-        $response = $this->factory->render('User/Edit', $props);
-        $page = $response->body;
-
-        $this->assertArrayNotHasKey('shared', $page['props']);
-        $this->assertArrayHasKey('auth', $page['props']);
-        $this->assertArrayNotHasKey('user', $page['props']['auth']);
-        $this->assertSame('value', $page['props']['auth']['shared_value']);
-    }
-
-    public function test_lazy_props_are_not_included_by_default(): void
-    {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
-
-        $lazyProp = new LazyProp(fn() => 'A lazy value');
-
-        $response = $this->factory->render('Users', [
-            'users' => [],
-            'lazy' => $lazyProp,
-        ]);
-
-        $page = $response->body;
-
-        $this->assertSame([], $page['props']['users']);
-        $this->assertArrayNotHasKey('lazy', $page['props']);
-    }
-
-    public function test_lazy_props_are_included_in_partial_reload(): void
-    {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [
-                Header::INERTIA => 'true',
-                Header::PARTIAL_COMPONENT => 'Users',
-                Header::PARTIAL_ONLY => 'lazy',
-            ],
-        );
-
-        $lazyProp = new LazyProp(fn() => 'A lazy value');
-
-        $response = $this->factory->render('Users', [
-            'users' => [],
-            'lazy' => $lazyProp,
-        ]);
-
-        $page = $response->body;
-
-        $this->assertArrayNotHasKey('users', $page['props']);
-        $this->assertSame('A lazy value', $page['props']['lazy']);
-    }
-
-    public function test_defer_arrayable_props_are_resolved_in_partial_reload(): void
-    {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [
-                Header::INERTIA => 'true',
-                Header::PARTIAL_COMPONENT => 'Users',
-                Header::PARTIAL_ONLY => 'defer',
-            ],
-        );
-
-        $deferProp = new DeferProp(function () {
-            return new class implements ArrayableInterface {
-                #[Override]
-                public function toArray(): array
-                {
-                    return ['foo' => 'bar'];
-                }
-            };
-        });
-
-        $response = $this->factory->render('Users', [
-            'users' => [],
-            'defer' => $deferProp,
-        ]);
-
-        $page = $response->body;
-
-        $this->assertArrayNotHasKey('users', $page['props']);
-        $this->assertSame(['foo' => 'bar'], $page['props']['defer']);
-    }
-
-    public function test_always_props_are_included_on_partial_reload(): void
-    {
-        $this->makeRequest(headers: [
-            Header::INERTIA => 'true',
-            Header::PARTIAL_COMPONENT => 'User/Edit',
-            Header::PARTIAL_ONLY => 'data',
-        ]);
-
-        $props = [
-            'user' => new LazyProp(fn() => [
-                'name' => 'Jonathan Reinink',
-                'email' => 'jonathan@example.com',
-            ]),
-            'data' => [
-                'name' => 'Taylor Otwell',
-            ],
-            'errors' => new AlwaysProp(fn() => [
-                'name' => 'The email field is required.',
-            ]),
-        ];
-
-        $response = $this->factory->render('User/Edit', $props);
-        $page = $response->body;
-
-        $this->assertSame('The email field is required.', $page['props']['errors']['name']);
-        $this->assertSame('Taylor Otwell', $page['props']['data']['name']);
-        $this->assertArrayNotHasKey('user', $page['props']);
-    }
-
-    public function test_inertia_responsable_objects(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'responsableProps']),
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $page = $response->body;
-        $props = $page['props'];
-
-        $this->assertSame('bar', $props['foo']);
-        $this->assertSame('qux', $props['baz']);
-        $this->assertSame('corge', $props['quux']);
-    }
-
-    public function test_props_can_be_merged_with_shared_data(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'mergeWithShared']),
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $page = $response->body;
-
-        $props = $page['props'];
-
-        $this->assertSame(['foo', 'bar'], $props['items']);
-        $this->assertSame(['foo', 'baz'], $props['deep']['foo']['bar']);
-    }
-
-    public function test_top_level_dot_props_get_unpacked(): void
-    {
-        $this->makeRequest(
-            uri: '/products/123',
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $props = [
-            'auth' => [
-                'user' => [
-                    'name' => 'Jonathan Reinink',
-                ],
-            ],
-            'auth.user.can' => [
-                'do.stuff' => true,
-            ],
-            'product' => ['name' => 'My example product'],
-        ];
-
-        $response = $this->factory->render('User/Edit', $props);
-        $page = $response->body;
-
-        $user = $page['props']['auth']['user'];
-        $this->assertSame('Jonathan Reinink', $user['name']);
-        $this->assertTrue($user['can']['do.stuff']);
-        $this->assertArrayNotHasKey('auth.user.can', $page['props']);
-    }
-
-    public function test_nested_dot_props_do_not_get_unpacked(): void
-    {
-        $this->makeRequest(
-            uri: '/products/123',
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $props = [
-            'auth' => [
-                'user.can' => [
-                    'do.stuff' => true,
-                ],
-                'user' => [
-                    'name' => 'Jonathan Reinink',
-                ],
-            ],
-            'product' => ['name' => 'My example product'],
-        ];
-
-        $response = $this->factory->render('User/Edit', $props);
-        $page = $response->body;
-
-        $auth = $page['props']['auth'];
-        $this->assertSame('Jonathan Reinink', $auth['user']['name']);
-        $this->assertTrue($auth['user.can']['do.stuff']);
-        $this->assertArrayNotHasKey('can', $auth);
-    }
-
-    public function test_props_can_be_added_using_the_with_method(): void
-    {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'withMethod']),
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $page = $response->body;
-        $props = $page['props'];
-
-        $this->assertSame('bar', $props['foo']);
-        $this->assertSame('qux', $props['baz']);
-        $this->assertSame('corge', $props['quux']);
-        $this->assertSame('garply', $props['grault']);
-    }
-
-    public function test_responsable_with_invalid_key(): void
-    {
-        $this->makeRequest(headers: [Header::INERTIA => 'true']);
-
-        $resource = new FakeResource(["\x00*\x00_invalid_key" => 'for object']);
-
-        $response = $this->factory->render('User/Edit', ['resource' => $resource]);
-        $page = $response->body;
-
-        $this->assertSame(["\x00*\x00_invalid_key" => 'for object'], $page['props']['resource']);
-    }
-
-    public function test_the_page_url_is_prefixed_with_the_proxy_prefix(): void
-    {
-        $this->makeRequest(headers: [Header::FORWARDED_PREFIX => '/sub/directory']);
-
-        $user = ['name' => 'Jonathan'];
-        $response = $this->factory->render('User/Edit', [
-            'user' => $user,
-        ]);
-
-        $page = $response->body->inertia['page'];
-        $resolvedBody = $response->body->jsonSerialize();
-
-        $this->assertInstanceOf(LazyBody::class, $response->body);
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-        $this->assertSame('/sub/directory/user/123', $page['url']);
-    }
-
-    public function test_the_page_url_doesnt_double_up(): void
-    {
-        $this->makeRequest(
-            uri: '/subpath/product/122',
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $response = $this->factory->render('Product/Show', []);
-        $page = $response->body;
-
-        $this->assertSame('/subpath/product/122', $page['url']);
-    }
-
-    public function test_trailing_slashes_in_a_url_are_preserved(): void
-    {
-        $this->makeRequest(
-            uri: '/users/',
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $response = $this->factory->render('User/Index', []);
-        $page = $response->body;
-
-        $this->assertSame('/users/', $page['url']);
-    }
-
-    public function test_trailing_slashes_in_a_url_with_query_parameters_are_preserved(): void
-    {
-        $this->makeRequest(
-            uri: '/users/?page=1&sort=name',
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $response = $this->factory->render('User/Index', []);
-        $page = $response->body;
-
-        $this->assertSame('/users/?page=1&sort=name', $page['url']);
-    }
-
-    public function test_a_url_without_trailing_slash_is_resolved_correctly(): void
-    {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $response = $this->factory->render('User/Index', []);
-        $page = $response->body;
-
-        $this->assertSame('/users', $page['url']);
-    }
-
-    public function test_a_url_without_trailing_slash_and_query_parameters_is_resolved_correctly(): void
-    {
-        $this->makeRequest(
-            uri: '/users?page=1&sort=name',
-            headers: [Header::INERTIA => 'true'],
-        );
-
-        $response = $this->factory->render('User/Index', []);
-        $page = $response->body;
-
-        $this->assertSame('/users?page=1&sort=name', $page['url']);
-    }
+  public function test_server_response(): void
+  {
+    $this->makeRequest();
+    $this->factory->version('123');
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+    ]);
+
+    $this->assertInstanceOf(LazyBody::class, $response->body);
+
+    $resolvedBody = $response->body->jsonSerialize();
+
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+    $renderer = $this->container->get(ViewRenderer::class);
+    $page = $response->body->inertia['page'];
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+    $this->assertFalse($page['clearHistory']);
+    $this->assertFalse($page['encryptHistory']);
+
+    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false}';
+    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
+    $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+  }
+
+  public function test_server_response_with_deferred_prop(): void
+  {
+    $this->makeRequest();
+    $this->factory->version('123');
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+      'foo' => new DeferProp(fn () => 'bar'),
+    ]);
+
+    $this->assertInstanceOf(LazyBody::class, $response->body);
+
+    $resolvedBody = $response->body->jsonSerialize();
+
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+    $renderer = $this->container->get(ViewRenderer::class);
+    $page = $response->body->inertia['page'];
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+    $this->assertFalse($page['clearHistory']);
+    $this->assertFalse($page['encryptHistory']);
+
+    $this->assertArrayNotHasKey('foo', $page['props']);
+    $this->assertSame(['default' => ['foo']], $page['deferredProps']);
+
+    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo"]}}';
+    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
+    $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+  }
+
+  public function test_server_response_with_deferred_prop_and_multiple_groups(): void
+  {
+    $this->makeRequest();
+    $this->factory->version('123');
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+      'foo' => new DeferProp(fn () => 'foo value'),
+      'bar' => new DeferProp(fn () => 'bar value'),
+      'baz' => new DeferProp(fn () => 'baz value', 'custom'),
+    ]);
+
+    $renderer = $this->container->get(ViewRenderer::class);
+    $page = $response->body->inertia['page'];
+    $resolvedBody = $response->body->jsonSerialize();
+
+    $this->assertInstanceOf(LazyBody::class, $response->body);
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+    $this->assertFalse($page['clearHistory']);
+    $this->assertFalse($page['encryptHistory']);
+
+    $this->assertArrayNotHasKey('foo', $page['props']);
+    $this->assertArrayNotHasKey('bar', $page['props']);
+    $this->assertArrayNotHasKey('baz', $page['props']);
+    $this->assertSame([
+      'default' => ['foo', 'bar'],
+      'custom' => ['baz'],
+    ], $page['deferredProps']);
+
+    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo","bar"],"custom":["baz"]}}';
+    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
+    $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+  }
+
+  public function test_server_response_with_merge_props(): void
+  {
+    $this->makeRequest();
+    $this->factory->version('123');
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+      'foo' => new MergeProp('foo value'),
+      'bar' => new MergeProp('bar value'),
+    ]);
+
+    $renderer = $this->container->get(ViewRenderer::class);
+    $page = $response->body->inertia['page'];
+    $resolvedBody = $response->body->jsonSerialize();
+
+    $this->assertInstanceOf(LazyBody::class, $response->body);
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+    $this->assertFalse($page['clearHistory']);
+    $this->assertFalse($page['encryptHistory']);
+
+    $this->assertSame('foo value', $page['props']['foo']);
+    $this->assertSame('bar value', $page['props']['bar']);
+    $this->assertSame(['foo', 'bar'], $page['mergeProps']);
+
+    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"]}';
+    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
+    $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+  }
+
+  public function test_server_response_with_deep_merge_props(): void
+  {
+    $this->makeRequest();
+    $this->factory->version('123');
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+      'foo' => new MergeProp('foo value')->deepMerge(),
+      'bar' => new MergeProp('bar value')->deepMerge(),
+    ]);
+
+    $renderer = $this->container->get(ViewRenderer::class);
+    $page = $response->body->inertia['page'];
+    $resolvedBody = $response->body->jsonSerialize();
+
+    $this->assertInstanceOf(LazyBody::class, $response->body);
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+    $this->assertFalse($page['clearHistory']);
+    $this->assertFalse($page['encryptHistory']);
+
+    $this->assertSame('foo value', $page['props']['foo']);
+    $this->assertSame('bar value', $page['props']['bar']);
+    $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
+
+    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"]}';
+    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
+    $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+  }
+
+  public function test_server_response_with_merge_strategies(): void
+  {
+    $this->makeRequest();
+    $this->factory->version('123');
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+      'foo' => new MergeProp('foo value')
+        ->matchOn('foo-key')
+        ->deepMerge(),
+      'bar' => new MergeProp('bar value')
+        ->matchOn('bar-key')
+        ->deepMerge(),
+    ]);
+
+    $renderer = $this->container->get(ViewRenderer::class);
+    $page = $response->body->inertia['page'];
+    $resolvedBody = $response->body->jsonSerialize();
+
+    $this->assertInstanceOf(LazyBody::class, $response->body);
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+    $this->assertFalse($page['clearHistory']);
+    $this->assertFalse($page['encryptHistory']);
+
+    $this->assertSame('foo value', $page['props']['foo']);
+    $this->assertSame('bar value', $page['props']['bar']);
+    $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
+    $this->assertSame(['foo.foo-key', 'bar.bar-key'], $page['matchPropsOn']);
+
+    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"matchPropsOn":["foo.foo-key","bar.bar-key"]}';
+    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
+    $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+  }
+
+  public function test_server_response_with_defer_and_merge_props(): void
+  {
+    $this->makeRequest();
+    $this->factory->version('123');
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+      'foo' => new DeferProp(fn () => 'foo value')->merge(),
+      'bar' => new MergeProp('bar value'),
+    ]);
+
+    $renderer = $this->container->get(ViewRenderer::class);
+    $page = $response->body->inertia['page'];
+    $resolvedBody = $response->body->jsonSerialize();
+
+    $this->assertInstanceOf(LazyBody::class, $response->body);
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+    $this->assertFalse($page['clearHistory']);
+    $this->assertFalse($page['encryptHistory']);
+
+    $this->assertArrayNotHasKey('foo', $page['props']);
+    $this->assertSame('bar value', $page['props']['bar']);
+    $this->assertSame(['default' => ['foo']], $page['deferredProps']);
+    $this->assertSame(['foo', 'bar'], $page['mergeProps']);
+
+    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}';
+    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
+    $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+  }
+
+  public function test_server_response_with_defer_and_deep_merge_props(): void
+  {
+    $this->makeRequest();
+    $this->factory->version('123');
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+      'foo' => new DeferProp(fn () => 'foo value')->deepMerge(),
+      'bar' => new MergeProp('bar value')->deepMerge(),
+    ]);
+
+    $renderer = $this->container->get(ViewRenderer::class);
+    $page = $response->body->inertia['page'];
+    $resolvedBody = $response->body->jsonSerialize();
+
+    $this->assertInstanceOf(LazyBody::class, $response->body);
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+    $this->assertFalse($page['clearHistory']);
+    $this->assertFalse($page['encryptHistory']);
+
+    $this->assertArrayNotHasKey('foo', $page['props']);
+    $this->assertSame('bar value', $page['props']['bar']);
+    $this->assertSame(['default' => ['foo']], $page['deferredProps']);
+    $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
+
+    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}';
+    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
+    $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+  }
+
+  public function test_exclude_merge_props_from_partial_only_response(): void
+  {
+    $this->makeRequest(headers: [
+      Header::INERTIA => 'true',
+      Header::PARTIAL_COMPONENT => 'User/Edit',
+      Header::PARTIAL_ONLY => 'user',
+    ]);
+    $this->factory->version('123');
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+      'foo' => new MergeProp('foo value'),
+      'bar' => new MergeProp('bar value'),
+    ]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+
+    $this->assertArrayHasKey('user', $page['props']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+
+    $this->assertArrayNotHasKey('foo', $page['props']);
+    $this->assertArrayNotHasKey('bar', $page['props']);
+    $this->assertArrayNotHasKey('mergeProps', $page);
+  }
+
+  public function test_exclude_merge_props_from_partial_except_response(): void
+  {
+    $this->makeRequest(headers: [
+      Header::INERTIA => 'true',
+      Header::PARTIAL_COMPONENT => 'User/Edit',
+      Header::PARTIAL_EXCEPT => 'foo',
+    ]);
+    $this->factory->version('123');
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+      'foo' => new MergeProp('foo value'),
+      'bar' => new MergeProp('bar value'),
+    ]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+
+    $this->assertArrayHasKey('user', $page['props']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertArrayHasKey('bar', $page['props']);
+    $this->assertSame('bar value', $page['props']['bar']);
+    $this->assertArrayNotHasKey('foo', $page['props']);
+    $this->assertSame(['bar'], $page['mergeProps']);
+  }
+
+  public function test_xhr_response(): void
+  {
+    $this->makeRequest(headers: [
+      Header::INERTIA => 'true',
+    ]);
+    $this->factory->version('123');
+
+    $user = (object) ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+    ]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']->name);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+  }
+
+  public function test_resource_response(): void
+  {
+    $this->makeRequest(headers: [
+      Header::INERTIA => 'true',
+    ]);
+    $this->factory->version('123');
+
+    $resource = new FakeResource(['name' => 'Jonathan']);
+    $response = $this->factory->render('User/Edit', ['user' => $resource]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+  }
+
+  public function test_lazy_callable_resource_response(): void
+  {
+    $this->makeRequest(
+      uri: '/users',
+      headers: [Header::INERTIA => 'true'],
+    );
+    $this->factory->version('123');
+
+    $response = $this->factory->render('User/Index', [
+      'users' => fn () => [['name' => 'Jonathan']],
+      'organizations' => fn () => [['name' => 'Inertia']],
+    ]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Index', $page['component']);
+    $this->assertSame('/users', $page['url']);
+    $this->assertSame('123', $page['version']);
+    $this->assertSame([['name' => 'Jonathan']], $page['props']['users']);
+    $this->assertSame([['name' => 'Inertia']], $page['props']['organizations']);
+  }
+
+  public function test_lazy_callable_resource_partial_response(): void
+  {
+    $this->makeRequest(
+      uri: '/users',
+      headers: [
+        Header::INERTIA => 'true',
+        Header::PARTIAL_COMPONENT => 'User/Index',
+        Header::PARTIAL_ONLY => 'users',
+      ],
+    );
+    $this->factory->version('123');
+
+    $response = $this->factory->render('User/Index', [
+      'users' => fn () => [['name' => 'Jonathan']],
+      'organizations' => fn () => [['name' => 'Inertia']],
+    ]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Index', $page['component']);
+    $this->assertSame('/users', $page['url']);
+    $this->assertSame('123', $page['version']);
+
+    $this->assertArrayHasKey('users', $page['props']);
+    $this->assertSame([['name' => 'Jonathan']], $page['props']['users']);
+    $this->assertArrayNotHasKey('organizations', $page['props']);
+  }
+
+  public function test_lazy_resource_response(): void
+  {
+    $this->makeRequest(
+      uri: '/users?page=1',
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $users = [
+      ['name' => 'Jonathan'],
+      ['name' => 'Taylor'],
+      ['name' => 'Jeffrey'],
+    ];
+
+    $callable = static function () use ($users) {
+      $paginator = new Paginator(
+        totalItems: count($users),
+        itemsPerPage: 2,
+        currentPage: 1,
+      );
+
+      return $paginator->paginate(array_slice($users, 0, 2));
+    };
+
+    $this->factory->version('123');
+    $response = $this->factory->render('User/Index', ['users' => $callable]);
+
+    $page = $response->body;
+
+    $this->assertSame('User/Index', $page['component']);
+    $this->assertSame('/users?page=1', $page['url']);
+    $this->assertSame('123', $page['version']);
+
+    $paginatedUsers = $page['props']['users'];
+
+    $this->assertArrayHasKey('data', $paginatedUsers);
+    $this->assertArrayHasKey('links', $paginatedUsers);
+    $this->assertArrayHasKey('meta', $paginatedUsers);
+
+    $this->assertSame([['name' => 'Jonathan'], ['name' => 'Taylor']], $paginatedUsers['data']);
+    $this->assertSame('/users?page=2', $paginatedUsers['links']['next']);
+    $this->assertSame(1, $paginatedUsers['meta']['current_page']);
+    $this->assertSame(3, $paginatedUsers['meta']['total']);
+  }
+
+  public function test_nested_lazy_resource_response(): void
+  {
+    $this->makeRequest(
+      uri: '/users?page=1',
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $users = [
+      ['name' => 'Jonathan'],
+      ['name' => 'Taylor'],
+      ['name' => 'Jeffrey'],
+    ];
+
+    $callable = static function () use ($users) {
+      $paginator = new Paginator(
+        totalItems: count($users),
+        itemsPerPage: 2,
+        currentPage: 1,
+      );
+
+      return [
+        'users' => $paginator->paginate(array_slice($users, 0, 2)),
+      ];
+    };
+
+    $this->factory->version('123');
+    $response = $this->factory->render('User/Index', ['something' => $callable]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Index', $page['component']);
+    $this->assertSame('/users?page=1', $page['url']);
+    $this->assertSame('123', $page['version']);
+
+    $nestedUsers = $page['props']['something']['users'];
+
+    $this->assertArrayHasKey('data', $nestedUsers);
+    $this->assertArrayHasKey('links', $nestedUsers);
+    $this->assertArrayHasKey('meta', $nestedUsers);
+    $this->assertSame([['name' => 'Jonathan'], ['name' => 'Taylor']], $nestedUsers['data']);
+    $this->assertSame('/users?page=2', $nestedUsers['links']['next']);
+    $this->assertSame('/users', $nestedUsers['meta']['path']);
+  }
+
+  public function test_arrayable_prop_response(): void
+  {
+    $this->makeRequest(headers: [
+      Header::INERTIA => 'true',
+    ]);
+
+    $this->factory->version('123');
+    $resource = new FakeResource(['name' => 'Jonathan']);
+    $response = $this->factory->render('User/Edit', ['user' => $resource]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']['name']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+  }
+
+  public function test_promise_props_are_resolved(): void
+  {
+    $this->makeRequest(headers: [Header::INERTIA => 'true']);
+
+    $user = (object) ['name' => 'Jonathan'];
+
+    $promise = Mockery::mock(PromiseInterface::class)
+      ->shouldReceive('wait')
+      ->once()
+      ->andReturn($user)
+      ->getMock();
+
+    $this->factory->version('123');
+    $response = $this->factory->render('User/Edit', ['user' => $promise]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('Jonathan', $page['props']['user']->name);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+  }
+
+  public function test_xhr_partial_response(): void
+  {
+    $this->makeRequest(headers: [
+      Header::INERTIA => 'true',
+      Header::PARTIAL_COMPONENT => 'User/Edit',
+      Header::PARTIAL_ONLY => 'partial',
+    ]);
+
+    $this->factory->version('123');
+    $response = $this->factory->render('User/Edit', [
+      'user' => (object) ['name' => 'Jonathan'],
+      'partial' => 'partial-data',
+    ]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+
+    $this->assertCount(1, $page['props']);
+    $this->assertArrayHasKey('partial', $page['props']);
+    $this->assertSame('partial-data', $page['props']['partial']);
+    $this->assertArrayNotHasKey('user', $page['props']);
+  }
+
+  public function test_exclude_props_from_partial_response(): void
+  {
+    $this->makeRequest(headers: [
+      Header::INERTIA => 'true',
+      Header::PARTIAL_COMPONENT => 'User/Edit',
+      Header::PARTIAL_EXCEPT => 'user',
+    ]);
+
+    $this->factory->version('123');
+    $response = $this->factory->render('User/Edit', [
+      'user' => (object) ['name' => 'Jonathan'],
+      'partial' => 'partial-data',
+    ]);
+
+    $page = $response->body->jsonSerialize();
+
+    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+    $this->assertSame('User/Edit', $page['component']);
+    $this->assertSame('/user/123', $page['url']);
+    $this->assertSame('123', $page['version']);
+
+    $this->assertCount(1, $page['props']);
+    $this->assertArrayHasKey('partial', $page['props']);
+    $this->assertSame('partial-data', $page['props']['partial']);
+    $this->assertArrayNotHasKey('user', $page['props']);
+  }
+
+  public function test_nested_partial_props(): void
+  {
+    $this->makeRequest(headers: [
+      Header::INERTIA => 'true',
+      Header::PARTIAL_COMPONENT => 'User/Edit',
+      Header::PARTIAL_ONLY => 'auth.user,auth.shared_value',
+    ]);
+
+    $props = [
+      'auth' => [
+        'user' => new LazyProp(fn () => [
+          'name' => 'Jonathan Reinink',
+          'email' => 'jonathan@example.com',
+        ]),
+        'shared_value' => 'value',
+        'value' => 'value',
+      ],
+      'shared' => [
+        'flash' => 'value',
+      ],
+    ];
+
+    $response = $this->factory->render('User/Edit', $props);
+    $page = $response->body;
+
+    $this->assertArrayNotHasKey('shared', $page['props']);
+    $this->assertArrayHasKey('auth', $page['props']);
+    $this->assertArrayNotHasKey('value', $page['props']['auth']);
+    $this->assertSame('Jonathan Reinink', $page['props']['auth']['user']['name']);
+    $this->assertSame('jonathan@example.com', $page['props']['auth']['user']['email']);
+    $this->assertSame('value', $page['props']['auth']['shared_value']);
+  }
+
+  public function test_exclude_nested_props_from_partial_response(): void
+  {
+    $this->makeRequest(headers: [
+      Header::INERTIA => 'true',
+      Header::PARTIAL_COMPONENT => 'User/Edit',
+      Header::PARTIAL_ONLY => 'auth',
+      Header::PARTIAL_EXCEPT => 'auth.user',
+    ]);
+
+    $props = [
+      'auth' => [
+        'user' => new LazyProp(fn () => [
+          'name' => 'Jonathan Reinink',
+          'email' => 'jonathan@example.com',
+        ]),
+        'shared_value' => 'value',
+      ],
+      'shared' => [
+        'flash' => 'value',
+      ],
+    ];
+
+    $response = $this->factory->render('User/Edit', $props);
+    $page = $response->body;
+
+    $this->assertArrayNotHasKey('shared', $page['props']);
+    $this->assertArrayHasKey('auth', $page['props']);
+    $this->assertArrayNotHasKey('user', $page['props']['auth']);
+    $this->assertSame('value', $page['props']['auth']['shared_value']);
+  }
+
+  public function test_lazy_props_are_not_included_by_default(): void
+  {
+    $this->makeRequest(
+      uri: '/users',
+      headers: [
+        Header::INERTIA => 'true',
+      ],
+    );
+
+    $lazyProp = new LazyProp(fn () => 'A lazy value');
+
+    $response = $this->factory->render('Users', [
+      'users' => [],
+      'lazy' => $lazyProp,
+    ]);
+
+    $page = $response->body;
+
+    $this->assertSame([], $page['props']['users']);
+    $this->assertArrayNotHasKey('lazy', $page['props']);
+  }
+
+  public function test_lazy_props_are_included_in_partial_reload(): void
+  {
+    $this->makeRequest(
+      uri: '/users',
+      headers: [
+        Header::INERTIA => 'true',
+        Header::PARTIAL_COMPONENT => 'Users',
+        Header::PARTIAL_ONLY => 'lazy',
+      ],
+    );
+
+    $lazyProp = new LazyProp(fn () => 'A lazy value');
+
+    $response = $this->factory->render('Users', [
+      'users' => [],
+      'lazy' => $lazyProp,
+    ]);
+
+    $page = $response->body;
+
+    $this->assertArrayNotHasKey('users', $page['props']);
+    $this->assertSame('A lazy value', $page['props']['lazy']);
+  }
+
+  public function test_defer_arrayable_props_are_resolved_in_partial_reload(): void
+  {
+    $this->makeRequest(
+      uri: '/users',
+      headers: [
+        Header::INERTIA => 'true',
+        Header::PARTIAL_COMPONENT => 'Users',
+        Header::PARTIAL_ONLY => 'defer',
+      ],
+    );
+
+    $deferProp = new DeferProp(function () {
+      return new class implements ArrayableInterface
+      {
+        #[Override]
+        public function toArray(): array
+        {
+          return ['foo' => 'bar'];
+        }
+      };
+    });
+
+    $response = $this->factory->render('Users', [
+      'users' => [],
+      'defer' => $deferProp,
+    ]);
+
+    $page = $response->body;
+
+    $this->assertArrayNotHasKey('users', $page['props']);
+    $this->assertSame(['foo' => 'bar'], $page['props']['defer']);
+  }
+
+  public function test_always_props_are_included_on_partial_reload(): void
+  {
+    $this->makeRequest(headers: [
+      Header::INERTIA => 'true',
+      Header::PARTIAL_COMPONENT => 'User/Edit',
+      Header::PARTIAL_ONLY => 'data',
+    ]);
+
+    $props = [
+      'user' => new LazyProp(fn () => [
+        'name' => 'Jonathan Reinink',
+        'email' => 'jonathan@example.com',
+      ]),
+      'data' => [
+        'name' => 'Taylor Otwell',
+      ],
+      'errors' => new AlwaysProp(fn () => [
+        'name' => 'The email field is required.',
+      ]),
+    ];
+
+    $response = $this->factory->render('User/Edit', $props);
+    $page = $response->body;
+
+    $this->assertSame('The email field is required.', $page['props']['errors']['name']);
+    $this->assertSame('Taylor Otwell', $page['props']['data']['name']);
+    $this->assertArrayNotHasKey('user', $page['props']);
+  }
+
+  public function test_inertia_responsable_objects(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'responsableProps']),
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $page = $response->body;
+    $props = $page['props'];
+
+    $this->assertSame('bar', $props['foo']);
+    $this->assertSame('qux', $props['baz']);
+    $this->assertSame('corge', $props['quux']);
+  }
+
+  public function test_props_can_be_merged_with_shared_data(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'mergeWithShared']),
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $page = $response->body;
+
+    $props = $page['props'];
+
+    $this->assertSame(['foo', 'bar'], $props['items']);
+    $this->assertSame(['foo', 'baz'], $props['deep']['foo']['bar']);
+  }
+
+  public function test_top_level_dot_props_get_unpacked(): void
+  {
+    $this->makeRequest(
+      uri: '/products/123',
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $props = [
+      'auth' => [
+        'user' => [
+          'name' => 'Jonathan Reinink',
+        ],
+      ],
+      'auth.user.can' => [
+        'do.stuff' => true,
+      ],
+      'product' => ['name' => 'My example product'],
+    ];
+
+    $response = $this->factory->render('User/Edit', $props);
+    $page = $response->body;
+
+    $user = $page['props']['auth']['user'];
+    $this->assertSame('Jonathan Reinink', $user['name']);
+    $this->assertTrue($user['can']['do.stuff']);
+    $this->assertArrayNotHasKey('auth.user.can', $page['props']);
+  }
+
+  public function test_nested_dot_props_do_not_get_unpacked(): void
+  {
+    $this->makeRequest(
+      uri: '/products/123',
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $props = [
+      'auth' => [
+        'user.can' => [
+          'do.stuff' => true,
+        ],
+        'user' => [
+          'name' => 'Jonathan Reinink',
+        ],
+      ],
+      'product' => ['name' => 'My example product'],
+    ];
+
+    $response = $this->factory->render('User/Edit', $props);
+    $page = $response->body;
+
+    $auth = $page['props']['auth'];
+    $this->assertSame('Jonathan Reinink', $auth['user']['name']);
+    $this->assertTrue($auth['user.can']['do.stuff']);
+    $this->assertArrayNotHasKey('can', $auth);
+  }
+
+  public function test_props_can_be_added_using_the_with_method(): void
+  {
+    $response = $this->http->get(
+      uri: uri([TestController::class, 'withMethod']),
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $page = $response->body;
+    $props = $page['props'];
+
+    $this->assertSame('bar', $props['foo']);
+    $this->assertSame('qux', $props['baz']);
+    $this->assertSame('corge', $props['quux']);
+    $this->assertSame('garply', $props['grault']);
+  }
+
+  public function test_responsable_with_invalid_key(): void
+  {
+    $this->makeRequest(headers: [Header::INERTIA => 'true']);
+
+    $resource = new FakeResource(["\x00*\x00_invalid_key" => 'for object']);
+
+    $response = $this->factory->render('User/Edit', ['resource' => $resource]);
+    $page = $response->body;
+
+    $this->assertSame(["\x00*\x00_invalid_key" => 'for object'], $page['props']['resource']);
+  }
+
+  public function test_the_page_url_is_prefixed_with_the_proxy_prefix(): void
+  {
+    $this->makeRequest(headers: [Header::FORWARDED_PREFIX => '/sub/directory']);
+
+    $user = ['name' => 'Jonathan'];
+    $response = $this->factory->render('User/Edit', [
+      'user' => $user,
+    ]);
+
+    $page = $response->body->inertia['page'];
+    $resolvedBody = $response->body->jsonSerialize();
+
+    $this->assertInstanceOf(LazyBody::class, $response->body);
+    $this->assertInstanceOf(Response::class, $response);
+    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+    $this->assertSame('/sub/directory/user/123', $page['url']);
+  }
+
+  public function test_the_page_url_doesnt_double_up(): void
+  {
+    $this->makeRequest(
+      uri: '/subpath/product/122',
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $response = $this->factory->render('Product/Show', []);
+    $page = $response->body;
+
+    $this->assertSame('/subpath/product/122', $page['url']);
+  }
+
+  public function test_trailing_slashes_in_a_url_are_preserved(): void
+  {
+    $this->makeRequest(
+      uri: '/users/',
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $response = $this->factory->render('User/Index', []);
+    $page = $response->body;
+
+    $this->assertSame('/users/', $page['url']);
+  }
+
+  public function test_trailing_slashes_in_a_url_with_query_parameters_are_preserved(): void
+  {
+    $this->makeRequest(
+      uri: '/users/?page=1&sort=name',
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $response = $this->factory->render('User/Index', []);
+    $page = $response->body;
+
+    $this->assertSame('/users/?page=1&sort=name', $page['url']);
+  }
+
+  public function test_a_url_without_trailing_slash_is_resolved_correctly(): void
+  {
+    $this->makeRequest(
+      uri: '/users',
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $response = $this->factory->render('User/Index', []);
+    $page = $response->body;
+
+    $this->assertSame('/users', $page['url']);
+  }
+
+  public function test_a_url_without_trailing_slash_and_query_parameters_is_resolved_correctly(): void
+  {
+    $this->makeRequest(
+      uri: '/users?page=1&sort=name',
+      headers: [Header::INERTIA => 'true'],
+    );
+
+    $response = $this->factory->render('User/Index', []);
+    $page = $response->body;
+
+    $this->assertSame('/users?page=1&sort=name', $page['url']);
+  }
 }

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -23,1024 +23,1023 @@ use function Tempest\Router\uri;
 
 class ResponseTest extends TestCase
 {
-  public function test_server_response(): void
-  {
-    $this->makeRequest();
-    $this->factory->version('123');
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-    ]);
-
-    $this->assertInstanceOf(LazyBody::class, $response->body);
-
-    $resolvedBody = $response->body->jsonSerialize();
-
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-    $renderer = $this->container->get(ViewRenderer::class);
-    $page = $response->body->inertia['page'];
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-    $this->assertFalse($page['clearHistory']);
-    $this->assertFalse($page['encryptHistory']);
-
-    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false}';
-    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
-    $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-  }
-
-  public function test_server_response_with_deferred_prop(): void
-  {
-    $this->makeRequest();
-    $this->factory->version('123');
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-      'foo' => new DeferProp(fn () => 'bar'),
-    ]);
-
-    $this->assertInstanceOf(LazyBody::class, $response->body);
-
-    $resolvedBody = $response->body->jsonSerialize();
-
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-    $renderer = $this->container->get(ViewRenderer::class);
-    $page = $response->body->inertia['page'];
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-    $this->assertFalse($page['clearHistory']);
-    $this->assertFalse($page['encryptHistory']);
-
-    $this->assertArrayNotHasKey('foo', $page['props']);
-    $this->assertSame(['default' => ['foo']], $page['deferredProps']);
-
-    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo"]}}';
-    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
-    $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-  }
-
-  public function test_server_response_with_deferred_prop_and_multiple_groups(): void
-  {
-    $this->makeRequest();
-    $this->factory->version('123');
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-      'foo' => new DeferProp(fn () => 'foo value'),
-      'bar' => new DeferProp(fn () => 'bar value'),
-      'baz' => new DeferProp(fn () => 'baz value', 'custom'),
-    ]);
-
-    $renderer = $this->container->get(ViewRenderer::class);
-    $page = $response->body->inertia['page'];
-    $resolvedBody = $response->body->jsonSerialize();
-
-    $this->assertInstanceOf(LazyBody::class, $response->body);
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-    $this->assertFalse($page['clearHistory']);
-    $this->assertFalse($page['encryptHistory']);
-
-    $this->assertArrayNotHasKey('foo', $page['props']);
-    $this->assertArrayNotHasKey('bar', $page['props']);
-    $this->assertArrayNotHasKey('baz', $page['props']);
-    $this->assertSame([
-      'default' => ['foo', 'bar'],
-      'custom' => ['baz'],
-    ], $page['deferredProps']);
-
-    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo","bar"],"custom":["baz"]}}';
-    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
-    $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-  }
-
-  public function test_server_response_with_merge_props(): void
-  {
-    $this->makeRequest();
-    $this->factory->version('123');
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-      'foo' => new MergeProp('foo value'),
-      'bar' => new MergeProp('bar value'),
-    ]);
-
-    $renderer = $this->container->get(ViewRenderer::class);
-    $page = $response->body->inertia['page'];
-    $resolvedBody = $response->body->jsonSerialize();
-
-    $this->assertInstanceOf(LazyBody::class, $response->body);
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-    $this->assertFalse($page['clearHistory']);
-    $this->assertFalse($page['encryptHistory']);
-
-    $this->assertSame('foo value', $page['props']['foo']);
-    $this->assertSame('bar value', $page['props']['bar']);
-    $this->assertSame(['foo', 'bar'], $page['mergeProps']);
-
-    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"]}';
-    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
-    $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-  }
-
-  public function test_server_response_with_deep_merge_props(): void
-  {
-    $this->makeRequest();
-    $this->factory->version('123');
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-      'foo' => new MergeProp('foo value')->deepMerge(),
-      'bar' => new MergeProp('bar value')->deepMerge(),
-    ]);
-
-    $renderer = $this->container->get(ViewRenderer::class);
-    $page = $response->body->inertia['page'];
-    $resolvedBody = $response->body->jsonSerialize();
-
-    $this->assertInstanceOf(LazyBody::class, $response->body);
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-    $this->assertFalse($page['clearHistory']);
-    $this->assertFalse($page['encryptHistory']);
-
-    $this->assertSame('foo value', $page['props']['foo']);
-    $this->assertSame('bar value', $page['props']['bar']);
-    $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
-
-    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"]}';
-    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
-    $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-  }
-
-  public function test_server_response_with_merge_strategies(): void
-  {
-    $this->makeRequest();
-    $this->factory->version('123');
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-      'foo' => new MergeProp('foo value')
-        ->matchOn('foo-key')
-        ->deepMerge(),
-      'bar' => new MergeProp('bar value')
-        ->matchOn('bar-key')
-        ->deepMerge(),
-    ]);
-
-    $renderer = $this->container->get(ViewRenderer::class);
-    $page = $response->body->inertia['page'];
-    $resolvedBody = $response->body->jsonSerialize();
-
-    $this->assertInstanceOf(LazyBody::class, $response->body);
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-    $this->assertFalse($page['clearHistory']);
-    $this->assertFalse($page['encryptHistory']);
-
-    $this->assertSame('foo value', $page['props']['foo']);
-    $this->assertSame('bar value', $page['props']['bar']);
-    $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
-    $this->assertSame(['foo.foo-key', 'bar.bar-key'], $page['matchPropsOn']);
-
-    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"matchPropsOn":["foo.foo-key","bar.bar-key"]}';
-    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
-    $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-  }
-
-  public function test_server_response_with_defer_and_merge_props(): void
-  {
-    $this->makeRequest();
-    $this->factory->version('123');
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-      'foo' => new DeferProp(fn () => 'foo value')->merge(),
-      'bar' => new MergeProp('bar value'),
-    ]);
-
-    $renderer = $this->container->get(ViewRenderer::class);
-    $page = $response->body->inertia['page'];
-    $resolvedBody = $response->body->jsonSerialize();
-
-    $this->assertInstanceOf(LazyBody::class, $response->body);
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-    $this->assertFalse($page['clearHistory']);
-    $this->assertFalse($page['encryptHistory']);
-
-    $this->assertArrayNotHasKey('foo', $page['props']);
-    $this->assertSame('bar value', $page['props']['bar']);
-    $this->assertSame(['default' => ['foo']], $page['deferredProps']);
-    $this->assertSame(['foo', 'bar'], $page['mergeProps']);
-
-    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}';
-    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
-    $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-  }
-
-  public function test_server_response_with_defer_and_deep_merge_props(): void
-  {
-    $this->makeRequest();
-    $this->factory->version('123');
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-      'foo' => new DeferProp(fn () => 'foo value')->deepMerge(),
-      'bar' => new MergeProp('bar value')->deepMerge(),
-    ]);
-
-    $renderer = $this->container->get(ViewRenderer::class);
-    $page = $response->body->inertia['page'];
-    $resolvedBody = $response->body->jsonSerialize();
-
-    $this->assertInstanceOf(LazyBody::class, $response->body);
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-    $this->assertFalse($page['clearHistory']);
-    $this->assertFalse($page['encryptHistory']);
-
-    $this->assertArrayNotHasKey('foo', $page['props']);
-    $this->assertSame('bar value', $page['props']['bar']);
-    $this->assertSame(['default' => ['foo']], $page['deferredProps']);
-    $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
-
-    $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}';
-    $expectedHtml = '<div id="app" data-page="'.htmlspecialchars($expectedJson, ENT_QUOTES).'"></div>';
-    $this->assertInstanceOf(ViewRenderer::class, $renderer);
-
-    $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
-  }
-
-  public function test_exclude_merge_props_from_partial_only_response(): void
-  {
-    $this->makeRequest(headers: [
-      Header::INERTIA => 'true',
-      Header::PARTIAL_COMPONENT => 'User/Edit',
-      Header::PARTIAL_ONLY => 'user',
-    ]);
-    $this->factory->version('123');
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-      'foo' => new MergeProp('foo value'),
-      'bar' => new MergeProp('bar value'),
-    ]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-
-    $this->assertArrayHasKey('user', $page['props']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-
-    $this->assertArrayNotHasKey('foo', $page['props']);
-    $this->assertArrayNotHasKey('bar', $page['props']);
-    $this->assertArrayNotHasKey('mergeProps', $page);
-  }
-
-  public function test_exclude_merge_props_from_partial_except_response(): void
-  {
-    $this->makeRequest(headers: [
-      Header::INERTIA => 'true',
-      Header::PARTIAL_COMPONENT => 'User/Edit',
-      Header::PARTIAL_EXCEPT => 'foo',
-    ]);
-    $this->factory->version('123');
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-      'foo' => new MergeProp('foo value'),
-      'bar' => new MergeProp('bar value'),
-    ]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-
-    $this->assertArrayHasKey('user', $page['props']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertArrayHasKey('bar', $page['props']);
-    $this->assertSame('bar value', $page['props']['bar']);
-    $this->assertArrayNotHasKey('foo', $page['props']);
-    $this->assertSame(['bar'], $page['mergeProps']);
-  }
-
-  public function test_xhr_response(): void
-  {
-    $this->makeRequest(headers: [
-      Header::INERTIA => 'true',
-    ]);
-    $this->factory->version('123');
-
-    $user = (object) ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-    ]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']->name);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-  }
-
-  public function test_resource_response(): void
-  {
-    $this->makeRequest(headers: [
-      Header::INERTIA => 'true',
-    ]);
-    $this->factory->version('123');
-
-    $resource = new FakeResource(['name' => 'Jonathan']);
-    $response = $this->factory->render('User/Edit', ['user' => $resource]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-  }
-
-  public function test_lazy_callable_resource_response(): void
-  {
-    $this->makeRequest(
-      uri: '/users',
-      headers: [Header::INERTIA => 'true'],
-    );
-    $this->factory->version('123');
-
-    $response = $this->factory->render('User/Index', [
-      'users' => fn () => [['name' => 'Jonathan']],
-      'organizations' => fn () => [['name' => 'Inertia']],
-    ]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Index', $page['component']);
-    $this->assertSame('/users', $page['url']);
-    $this->assertSame('123', $page['version']);
-    $this->assertSame([['name' => 'Jonathan']], $page['props']['users']);
-    $this->assertSame([['name' => 'Inertia']], $page['props']['organizations']);
-  }
-
-  public function test_lazy_callable_resource_partial_response(): void
-  {
-    $this->makeRequest(
-      uri: '/users',
-      headers: [
-        Header::INERTIA => 'true',
-        Header::PARTIAL_COMPONENT => 'User/Index',
-        Header::PARTIAL_ONLY => 'users',
-      ],
-    );
-    $this->factory->version('123');
-
-    $response = $this->factory->render('User/Index', [
-      'users' => fn () => [['name' => 'Jonathan']],
-      'organizations' => fn () => [['name' => 'Inertia']],
-    ]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Index', $page['component']);
-    $this->assertSame('/users', $page['url']);
-    $this->assertSame('123', $page['version']);
-
-    $this->assertArrayHasKey('users', $page['props']);
-    $this->assertSame([['name' => 'Jonathan']], $page['props']['users']);
-    $this->assertArrayNotHasKey('organizations', $page['props']);
-  }
-
-  public function test_lazy_resource_response(): void
-  {
-    $this->makeRequest(
-      uri: '/users?page=1',
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $users = [
-      ['name' => 'Jonathan'],
-      ['name' => 'Taylor'],
-      ['name' => 'Jeffrey'],
-    ];
-
-    $callable = static function () use ($users) {
-      $paginator = new Paginator(
-        totalItems: count($users),
-        itemsPerPage: 2,
-        currentPage: 1,
-      );
-
-      return $paginator->paginate(array_slice($users, 0, 2));
-    };
-
-    $this->factory->version('123');
-    $response = $this->factory->render('User/Index', ['users' => $callable]);
-
-    $page = $response->body;
-
-    $this->assertSame('User/Index', $page['component']);
-    $this->assertSame('/users?page=1', $page['url']);
-    $this->assertSame('123', $page['version']);
-
-    $paginatedUsers = $page['props']['users'];
-
-    $this->assertArrayHasKey('data', $paginatedUsers);
-    $this->assertArrayHasKey('links', $paginatedUsers);
-    $this->assertArrayHasKey('meta', $paginatedUsers);
-
-    $this->assertSame([['name' => 'Jonathan'], ['name' => 'Taylor']], $paginatedUsers['data']);
-    $this->assertSame('/users?page=2', $paginatedUsers['links']['next']);
-    $this->assertSame(1, $paginatedUsers['meta']['current_page']);
-    $this->assertSame(3, $paginatedUsers['meta']['total']);
-  }
-
-  public function test_nested_lazy_resource_response(): void
-  {
-    $this->makeRequest(
-      uri: '/users?page=1',
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $users = [
-      ['name' => 'Jonathan'],
-      ['name' => 'Taylor'],
-      ['name' => 'Jeffrey'],
-    ];
-
-    $callable = static function () use ($users) {
-      $paginator = new Paginator(
-        totalItems: count($users),
-        itemsPerPage: 2,
-        currentPage: 1,
-      );
-
-      return [
-        'users' => $paginator->paginate(array_slice($users, 0, 2)),
-      ];
-    };
-
-    $this->factory->version('123');
-    $response = $this->factory->render('User/Index', ['something' => $callable]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Index', $page['component']);
-    $this->assertSame('/users?page=1', $page['url']);
-    $this->assertSame('123', $page['version']);
-
-    $nestedUsers = $page['props']['something']['users'];
-
-    $this->assertArrayHasKey('data', $nestedUsers);
-    $this->assertArrayHasKey('links', $nestedUsers);
-    $this->assertArrayHasKey('meta', $nestedUsers);
-    $this->assertSame([['name' => 'Jonathan'], ['name' => 'Taylor']], $nestedUsers['data']);
-    $this->assertSame('/users?page=2', $nestedUsers['links']['next']);
-    $this->assertSame('/users', $nestedUsers['meta']['path']);
-  }
-
-  public function test_arrayable_prop_response(): void
-  {
-    $this->makeRequest(headers: [
-      Header::INERTIA => 'true',
-    ]);
-
-    $this->factory->version('123');
-    $resource = new FakeResource(['name' => 'Jonathan']);
-    $response = $this->factory->render('User/Edit', ['user' => $resource]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']['name']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-  }
-
-  public function test_promise_props_are_resolved(): void
-  {
-    $this->makeRequest(headers: [Header::INERTIA => 'true']);
-
-    $user = (object) ['name' => 'Jonathan'];
-
-    $promise = Mockery::mock(PromiseInterface::class)
-      ->shouldReceive('wait')
-      ->once()
-      ->andReturn($user)
-      ->getMock();
-
-    $this->factory->version('123');
-    $response = $this->factory->render('User/Edit', ['user' => $promise]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('Jonathan', $page['props']['user']->name);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-  }
-
-  public function test_xhr_partial_response(): void
-  {
-    $this->makeRequest(headers: [
-      Header::INERTIA => 'true',
-      Header::PARTIAL_COMPONENT => 'User/Edit',
-      Header::PARTIAL_ONLY => 'partial',
-    ]);
-
-    $this->factory->version('123');
-    $response = $this->factory->render('User/Edit', [
-      'user' => (object) ['name' => 'Jonathan'],
-      'partial' => 'partial-data',
-    ]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-
-    $this->assertCount(1, $page['props']);
-    $this->assertArrayHasKey('partial', $page['props']);
-    $this->assertSame('partial-data', $page['props']['partial']);
-    $this->assertArrayNotHasKey('user', $page['props']);
-  }
-
-  public function test_exclude_props_from_partial_response(): void
-  {
-    $this->makeRequest(headers: [
-      Header::INERTIA => 'true',
-      Header::PARTIAL_COMPONENT => 'User/Edit',
-      Header::PARTIAL_EXCEPT => 'user',
-    ]);
-
-    $this->factory->version('123');
-    $response = $this->factory->render('User/Edit', [
-      'user' => (object) ['name' => 'Jonathan'],
-      'partial' => 'partial-data',
-    ]);
-
-    $page = $response->body->jsonSerialize();
-
-    $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
-    $this->assertSame('User/Edit', $page['component']);
-    $this->assertSame('/user/123', $page['url']);
-    $this->assertSame('123', $page['version']);
-
-    $this->assertCount(1, $page['props']);
-    $this->assertArrayHasKey('partial', $page['props']);
-    $this->assertSame('partial-data', $page['props']['partial']);
-    $this->assertArrayNotHasKey('user', $page['props']);
-  }
-
-  public function test_nested_partial_props(): void
-  {
-    $this->makeRequest(headers: [
-      Header::INERTIA => 'true',
-      Header::PARTIAL_COMPONENT => 'User/Edit',
-      Header::PARTIAL_ONLY => 'auth.user,auth.shared_value',
-    ]);
-
-    $props = [
-      'auth' => [
-        'user' => new LazyProp(fn () => [
-          'name' => 'Jonathan Reinink',
-          'email' => 'jonathan@example.com',
-        ]),
-        'shared_value' => 'value',
-        'value' => 'value',
-      ],
-      'shared' => [
-        'flash' => 'value',
-      ],
-    ];
-
-    $response = $this->factory->render('User/Edit', $props);
-    $page = $response->body;
-
-    $this->assertArrayNotHasKey('shared', $page['props']);
-    $this->assertArrayHasKey('auth', $page['props']);
-    $this->assertArrayNotHasKey('value', $page['props']['auth']);
-    $this->assertSame('Jonathan Reinink', $page['props']['auth']['user']['name']);
-    $this->assertSame('jonathan@example.com', $page['props']['auth']['user']['email']);
-    $this->assertSame('value', $page['props']['auth']['shared_value']);
-  }
-
-  public function test_exclude_nested_props_from_partial_response(): void
-  {
-    $this->makeRequest(headers: [
-      Header::INERTIA => 'true',
-      Header::PARTIAL_COMPONENT => 'User/Edit',
-      Header::PARTIAL_ONLY => 'auth',
-      Header::PARTIAL_EXCEPT => 'auth.user',
-    ]);
-
-    $props = [
-      'auth' => [
-        'user' => new LazyProp(fn () => [
-          'name' => 'Jonathan Reinink',
-          'email' => 'jonathan@example.com',
-        ]),
-        'shared_value' => 'value',
-      ],
-      'shared' => [
-        'flash' => 'value',
-      ],
-    ];
-
-    $response = $this->factory->render('User/Edit', $props);
-    $page = $response->body;
-
-    $this->assertArrayNotHasKey('shared', $page['props']);
-    $this->assertArrayHasKey('auth', $page['props']);
-    $this->assertArrayNotHasKey('user', $page['props']['auth']);
-    $this->assertSame('value', $page['props']['auth']['shared_value']);
-  }
-
-  public function test_lazy_props_are_not_included_by_default(): void
-  {
-    $this->makeRequest(
-      uri: '/users',
-      headers: [
-        Header::INERTIA => 'true',
-      ],
-    );
-
-    $lazyProp = new LazyProp(fn () => 'A lazy value');
-
-    $response = $this->factory->render('Users', [
-      'users' => [],
-      'lazy' => $lazyProp,
-    ]);
-
-    $page = $response->body;
-
-    $this->assertSame([], $page['props']['users']);
-    $this->assertArrayNotHasKey('lazy', $page['props']);
-  }
-
-  public function test_lazy_props_are_included_in_partial_reload(): void
-  {
-    $this->makeRequest(
-      uri: '/users',
-      headers: [
-        Header::INERTIA => 'true',
-        Header::PARTIAL_COMPONENT => 'Users',
-        Header::PARTIAL_ONLY => 'lazy',
-      ],
-    );
-
-    $lazyProp = new LazyProp(fn () => 'A lazy value');
-
-    $response = $this->factory->render('Users', [
-      'users' => [],
-      'lazy' => $lazyProp,
-    ]);
-
-    $page = $response->body;
-
-    $this->assertArrayNotHasKey('users', $page['props']);
-    $this->assertSame('A lazy value', $page['props']['lazy']);
-  }
-
-  public function test_defer_arrayable_props_are_resolved_in_partial_reload(): void
-  {
-    $this->makeRequest(
-      uri: '/users',
-      headers: [
-        Header::INERTIA => 'true',
-        Header::PARTIAL_COMPONENT => 'Users',
-        Header::PARTIAL_ONLY => 'defer',
-      ],
-    );
-
-    $deferProp = new DeferProp(function () {
-      return new class implements ArrayableInterface
-      {
-        #[Override]
-        public function toArray(): array
-        {
-          return ['foo' => 'bar'];
-        }
-      };
-    });
-
-    $response = $this->factory->render('Users', [
-      'users' => [],
-      'defer' => $deferProp,
-    ]);
-
-    $page = $response->body;
-
-    $this->assertArrayNotHasKey('users', $page['props']);
-    $this->assertSame(['foo' => 'bar'], $page['props']['defer']);
-  }
-
-  public function test_always_props_are_included_on_partial_reload(): void
-  {
-    $this->makeRequest(headers: [
-      Header::INERTIA => 'true',
-      Header::PARTIAL_COMPONENT => 'User/Edit',
-      Header::PARTIAL_ONLY => 'data',
-    ]);
-
-    $props = [
-      'user' => new LazyProp(fn () => [
-        'name' => 'Jonathan Reinink',
-        'email' => 'jonathan@example.com',
-      ]),
-      'data' => [
-        'name' => 'Taylor Otwell',
-      ],
-      'errors' => new AlwaysProp(fn () => [
-        'name' => 'The email field is required.',
-      ]),
-    ];
-
-    $response = $this->factory->render('User/Edit', $props);
-    $page = $response->body;
-
-    $this->assertSame('The email field is required.', $page['props']['errors']['name']);
-    $this->assertSame('Taylor Otwell', $page['props']['data']['name']);
-    $this->assertArrayNotHasKey('user', $page['props']);
-  }
-
-  public function test_inertia_responsable_objects(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'responsableProps']),
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $page = $response->body;
-    $props = $page['props'];
-
-    $this->assertSame('bar', $props['foo']);
-    $this->assertSame('qux', $props['baz']);
-    $this->assertSame('corge', $props['quux']);
-  }
-
-  public function test_props_can_be_merged_with_shared_data(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'mergeWithShared']),
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $page = $response->body;
-
-    $props = $page['props'];
-
-    $this->assertSame(['foo', 'bar'], $props['items']);
-    $this->assertSame(['foo', 'baz'], $props['deep']['foo']['bar']);
-  }
-
-  public function test_top_level_dot_props_get_unpacked(): void
-  {
-    $this->makeRequest(
-      uri: '/products/123',
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $props = [
-      'auth' => [
-        'user' => [
-          'name' => 'Jonathan Reinink',
-        ],
-      ],
-      'auth.user.can' => [
-        'do.stuff' => true,
-      ],
-      'product' => ['name' => 'My example product'],
-    ];
-
-    $response = $this->factory->render('User/Edit', $props);
-    $page = $response->body;
-
-    $user = $page['props']['auth']['user'];
-    $this->assertSame('Jonathan Reinink', $user['name']);
-    $this->assertTrue($user['can']['do.stuff']);
-    $this->assertArrayNotHasKey('auth.user.can', $page['props']);
-  }
-
-  public function test_nested_dot_props_do_not_get_unpacked(): void
-  {
-    $this->makeRequest(
-      uri: '/products/123',
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $props = [
-      'auth' => [
-        'user.can' => [
-          'do.stuff' => true,
-        ],
-        'user' => [
-          'name' => 'Jonathan Reinink',
-        ],
-      ],
-      'product' => ['name' => 'My example product'],
-    ];
-
-    $response = $this->factory->render('User/Edit', $props);
-    $page = $response->body;
-
-    $auth = $page['props']['auth'];
-    $this->assertSame('Jonathan Reinink', $auth['user']['name']);
-    $this->assertTrue($auth['user.can']['do.stuff']);
-    $this->assertArrayNotHasKey('can', $auth);
-  }
-
-  public function test_props_can_be_added_using_the_with_method(): void
-  {
-    $response = $this->http->get(
-      uri: uri([TestController::class, 'withMethod']),
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $page = $response->body;
-    $props = $page['props'];
-
-    $this->assertSame('bar', $props['foo']);
-    $this->assertSame('qux', $props['baz']);
-    $this->assertSame('corge', $props['quux']);
-    $this->assertSame('garply', $props['grault']);
-  }
-
-  public function test_responsable_with_invalid_key(): void
-  {
-    $this->makeRequest(headers: [Header::INERTIA => 'true']);
-
-    $resource = new FakeResource(["\x00*\x00_invalid_key" => 'for object']);
-
-    $response = $this->factory->render('User/Edit', ['resource' => $resource]);
-    $page = $response->body;
-
-    $this->assertSame(["\x00*\x00_invalid_key" => 'for object'], $page['props']['resource']);
-  }
-
-  public function test_the_page_url_is_prefixed_with_the_proxy_prefix(): void
-  {
-    $this->makeRequest(headers: [Header::FORWARDED_PREFIX => '/sub/directory']);
-
-    $user = ['name' => 'Jonathan'];
-    $response = $this->factory->render('User/Edit', [
-      'user' => $user,
-    ]);
-
-    $page = $response->body->inertia['page'];
-    $resolvedBody = $response->body->jsonSerialize();
-
-    $this->assertInstanceOf(LazyBody::class, $response->body);
-    $this->assertInstanceOf(Response::class, $response);
-    $this->assertInstanceOf(InertiaView::class, $resolvedBody);
-    $this->assertSame('/sub/directory/user/123', $page['url']);
-  }
-
-  public function test_the_page_url_doesnt_double_up(): void
-  {
-    $this->makeRequest(
-      uri: '/subpath/product/122',
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $response = $this->factory->render('Product/Show', []);
-    $page = $response->body;
-
-    $this->assertSame('/subpath/product/122', $page['url']);
-  }
-
-  public function test_trailing_slashes_in_a_url_are_preserved(): void
-  {
-    $this->makeRequest(
-      uri: '/users/',
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $response = $this->factory->render('User/Index', []);
-    $page = $response->body;
-
-    $this->assertSame('/users/', $page['url']);
-  }
-
-  public function test_trailing_slashes_in_a_url_with_query_parameters_are_preserved(): void
-  {
-    $this->makeRequest(
-      uri: '/users/?page=1&sort=name',
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $response = $this->factory->render('User/Index', []);
-    $page = $response->body;
-
-    $this->assertSame('/users/?page=1&sort=name', $page['url']);
-  }
-
-  public function test_a_url_without_trailing_slash_is_resolved_correctly(): void
-  {
-    $this->makeRequest(
-      uri: '/users',
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $response = $this->factory->render('User/Index', []);
-    $page = $response->body;
-
-    $this->assertSame('/users', $page['url']);
-  }
-
-  public function test_a_url_without_trailing_slash_and_query_parameters_is_resolved_correctly(): void
-  {
-    $this->makeRequest(
-      uri: '/users?page=1&sort=name',
-      headers: [Header::INERTIA => 'true'],
-    );
-
-    $response = $this->factory->render('User/Index', []);
-    $page = $response->body;
-
-    $this->assertSame('/users?page=1&sort=name', $page['url']);
-  }
+    public function test_server_response(): void
+    {
+        $this->makeRequest();
+        $this->factory->version('123');
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+        ]);
+
+        $this->assertInstanceOf(LazyBody::class, $response->body);
+
+        $resolvedBody = $response->body->jsonSerialize();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+        $renderer = $this->container->get(ViewRenderer::class);
+        $page = $response->body->inertia['page'];
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+
+        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false}';
+        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+    }
+
+    public function test_server_response_with_deferred_prop(): void
+    {
+        $this->makeRequest();
+        $this->factory->version('123');
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+            'foo' => new DeferProp(fn() => 'bar'),
+        ]);
+
+        $this->assertInstanceOf(LazyBody::class, $response->body);
+
+        $resolvedBody = $response->body->jsonSerialize();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+        $renderer = $this->container->get(ViewRenderer::class);
+        $page = $response->body->inertia['page'];
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertSame(['default' => ['foo']], $page['deferredProps']);
+
+        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo"]}}';
+        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+    }
+
+    public function test_server_response_with_deferred_prop_and_multiple_groups(): void
+    {
+        $this->makeRequest();
+        $this->factory->version('123');
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+            'foo' => new DeferProp(fn() => 'foo value'),
+            'bar' => new DeferProp(fn() => 'bar value'),
+            'baz' => new DeferProp(fn() => 'baz value', 'custom'),
+        ]);
+
+        $renderer = $this->container->get(ViewRenderer::class);
+        $page = $response->body->inertia['page'];
+        $resolvedBody = $response->body->jsonSerialize();
+
+        $this->assertInstanceOf(LazyBody::class, $response->body);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertArrayNotHasKey('bar', $page['props']);
+        $this->assertArrayNotHasKey('baz', $page['props']);
+        $this->assertSame([
+            'default' => ['foo', 'bar'],
+            'custom' => ['baz'],
+        ], $page['deferredProps']);
+
+        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo","bar"],"custom":["baz"]}}';
+        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+    }
+
+    public function test_server_response_with_merge_props(): void
+    {
+        $this->makeRequest();
+        $this->factory->version('123');
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+            'foo' => new MergeProp('foo value'),
+            'bar' => new MergeProp('bar value'),
+        ]);
+
+        $renderer = $this->container->get(ViewRenderer::class);
+        $page = $response->body->inertia['page'];
+        $resolvedBody = $response->body->jsonSerialize();
+
+        $this->assertInstanceOf(LazyBody::class, $response->body);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+
+        $this->assertSame('foo value', $page['props']['foo']);
+        $this->assertSame('bar value', $page['props']['bar']);
+        $this->assertSame(['foo', 'bar'], $page['mergeProps']);
+
+        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"]}';
+        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+    }
+
+    public function test_server_response_with_deep_merge_props(): void
+    {
+        $this->makeRequest();
+        $this->factory->version('123');
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+            'foo' => new MergeProp('foo value')->deepMerge(),
+            'bar' => new MergeProp('bar value')->deepMerge(),
+        ]);
+
+        $renderer = $this->container->get(ViewRenderer::class);
+        $page = $response->body->inertia['page'];
+        $resolvedBody = $response->body->jsonSerialize();
+
+        $this->assertInstanceOf(LazyBody::class, $response->body);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+
+        $this->assertSame('foo value', $page['props']['foo']);
+        $this->assertSame('bar value', $page['props']['bar']);
+        $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
+
+        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"]}';
+        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+    }
+
+    public function test_server_response_with_merge_strategies(): void
+    {
+        $this->makeRequest();
+        $this->factory->version('123');
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+            'foo' => new MergeProp('foo value')
+                ->matchOn('foo-key')
+                ->deepMerge(),
+            'bar' => new MergeProp('bar value')
+                ->matchOn('bar-key')
+                ->deepMerge(),
+        ]);
+
+        $renderer = $this->container->get(ViewRenderer::class);
+        $page = $response->body->inertia['page'];
+        $resolvedBody = $response->body->jsonSerialize();
+
+        $this->assertInstanceOf(LazyBody::class, $response->body);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+
+        $this->assertSame('foo value', $page['props']['foo']);
+        $this->assertSame('bar value', $page['props']['bar']);
+        $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
+        $this->assertSame(['foo.foo-key', 'bar.bar-key'], $page['matchPropsOn']);
+
+        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"matchPropsOn":["foo.foo-key","bar.bar-key"]}';
+        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+    }
+
+    public function test_server_response_with_defer_and_merge_props(): void
+    {
+        $this->makeRequest();
+        $this->factory->version('123');
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+            'foo' => new DeferProp(fn() => 'foo value')->merge(),
+            'bar' => new MergeProp('bar value'),
+        ]);
+
+        $renderer = $this->container->get(ViewRenderer::class);
+        $page = $response->body->inertia['page'];
+        $resolvedBody = $response->body->jsonSerialize();
+
+        $this->assertInstanceOf(LazyBody::class, $response->body);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertSame('bar value', $page['props']['bar']);
+        $this->assertSame(['default' => ['foo']], $page['deferredProps']);
+        $this->assertSame(['foo', 'bar'], $page['mergeProps']);
+
+        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}';
+        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+    }
+
+    public function test_server_response_with_defer_and_deep_merge_props(): void
+    {
+        $this->makeRequest();
+        $this->factory->version('123');
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+            'foo' => new DeferProp(fn() => 'foo value')->deepMerge(),
+            'bar' => new MergeProp('bar value')->deepMerge(),
+        ]);
+
+        $renderer = $this->container->get(ViewRenderer::class);
+        $page = $response->body->inertia['page'];
+        $resolvedBody = $response->body->jsonSerialize();
+
+        $this->assertInstanceOf(LazyBody::class, $response->body);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertSame('bar value', $page['props']['bar']);
+        $this->assertSame(['default' => ['foo']], $page['deferredProps']);
+        $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
+
+        $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}';
+        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $this->assertInstanceOf(ViewRenderer::class, $renderer);
+
+        $this->assertSame($expectedHtml, $renderer->render($resolvedBody));
+    }
+
+    public function test_exclude_merge_props_from_partial_only_response(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'user',
+        ]);
+        $this->factory->version('123');
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+            'foo' => new MergeProp('foo value'),
+            'bar' => new MergeProp('bar value'),
+        ]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+
+        $this->assertArrayHasKey('user', $page['props']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertArrayNotHasKey('bar', $page['props']);
+        $this->assertArrayNotHasKey('mergeProps', $page);
+    }
+
+    public function test_exclude_merge_props_from_partial_except_response(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_EXCEPT => 'foo',
+        ]);
+        $this->factory->version('123');
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+            'foo' => new MergeProp('foo value'),
+            'bar' => new MergeProp('bar value'),
+        ]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+
+        $this->assertArrayHasKey('user', $page['props']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertArrayHasKey('bar', $page['props']);
+        $this->assertSame('bar value', $page['props']['bar']);
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertSame(['bar'], $page['mergeProps']);
+    }
+
+    public function test_xhr_response(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+        ]);
+        $this->factory->version('123');
+
+        $user = (object) ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+        ]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']->name);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+    }
+
+    public function test_resource_response(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+        ]);
+        $this->factory->version('123');
+
+        $resource = new FakeResource(['name' => 'Jonathan']);
+        $response = $this->factory->render('User/Edit', ['user' => $resource]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+    }
+
+    public function test_lazy_callable_resource_response(): void
+    {
+        $this->makeRequest(
+            uri: '/users',
+            headers: [Header::INERTIA => 'true'],
+        );
+        $this->factory->version('123');
+
+        $response = $this->factory->render('User/Index', [
+            'users' => fn() => [['name' => 'Jonathan']],
+            'organizations' => fn() => [['name' => 'Inertia']],
+        ]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Index', $page['component']);
+        $this->assertSame('/users', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertSame([['name' => 'Jonathan']], $page['props']['users']);
+        $this->assertSame([['name' => 'Inertia']], $page['props']['organizations']);
+    }
+
+    public function test_lazy_callable_resource_partial_response(): void
+    {
+        $this->makeRequest(
+            uri: '/users',
+            headers: [
+                Header::INERTIA => 'true',
+                Header::PARTIAL_COMPONENT => 'User/Index',
+                Header::PARTIAL_ONLY => 'users',
+            ],
+        );
+        $this->factory->version('123');
+
+        $response = $this->factory->render('User/Index', [
+            'users' => fn() => [['name' => 'Jonathan']],
+            'organizations' => fn() => [['name' => 'Inertia']],
+        ]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Index', $page['component']);
+        $this->assertSame('/users', $page['url']);
+        $this->assertSame('123', $page['version']);
+
+        $this->assertArrayHasKey('users', $page['props']);
+        $this->assertSame([['name' => 'Jonathan']], $page['props']['users']);
+        $this->assertArrayNotHasKey('organizations', $page['props']);
+    }
+
+    public function test_lazy_resource_response(): void
+    {
+        $this->makeRequest(
+            uri: '/users?page=1',
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $users = [
+            ['name' => 'Jonathan'],
+            ['name' => 'Taylor'],
+            ['name' => 'Jeffrey'],
+        ];
+
+        $callable = static function () use ($users) {
+            $paginator = new Paginator(
+                totalItems: count($users),
+                itemsPerPage: 2,
+                currentPage: 1,
+            );
+
+            return $paginator->paginate(array_slice($users, 0, 2));
+        };
+
+        $this->factory->version('123');
+        $response = $this->factory->render('User/Index', ['users' => $callable]);
+
+        $page = $response->body;
+
+        $this->assertSame('User/Index', $page['component']);
+        $this->assertSame('/users?page=1', $page['url']);
+        $this->assertSame('123', $page['version']);
+
+        $paginatedUsers = $page['props']['users'];
+
+        $this->assertArrayHasKey('data', $paginatedUsers);
+        $this->assertArrayHasKey('links', $paginatedUsers);
+        $this->assertArrayHasKey('meta', $paginatedUsers);
+
+        $this->assertSame([['name' => 'Jonathan'], ['name' => 'Taylor']], $paginatedUsers['data']);
+        $this->assertSame('/users?page=2', $paginatedUsers['links']['next']);
+        $this->assertSame(1, $paginatedUsers['meta']['current_page']);
+        $this->assertSame(3, $paginatedUsers['meta']['total']);
+    }
+
+    public function test_nested_lazy_resource_response(): void
+    {
+        $this->makeRequest(
+            uri: '/users?page=1',
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $users = [
+            ['name' => 'Jonathan'],
+            ['name' => 'Taylor'],
+            ['name' => 'Jeffrey'],
+        ];
+
+        $callable = static function () use ($users) {
+            $paginator = new Paginator(
+                totalItems: count($users),
+                itemsPerPage: 2,
+                currentPage: 1,
+            );
+
+            return [
+                'users' => $paginator->paginate(array_slice($users, 0, 2)),
+            ];
+        };
+
+        $this->factory->version('123');
+        $response = $this->factory->render('User/Index', ['something' => $callable]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Index', $page['component']);
+        $this->assertSame('/users?page=1', $page['url']);
+        $this->assertSame('123', $page['version']);
+
+        $nestedUsers = $page['props']['something']['users'];
+
+        $this->assertArrayHasKey('data', $nestedUsers);
+        $this->assertArrayHasKey('links', $nestedUsers);
+        $this->assertArrayHasKey('meta', $nestedUsers);
+        $this->assertSame([['name' => 'Jonathan'], ['name' => 'Taylor']], $nestedUsers['data']);
+        $this->assertSame('/users?page=2', $nestedUsers['links']['next']);
+        $this->assertSame('/users', $nestedUsers['meta']['path']);
+    }
+
+    public function test_arrayable_prop_response(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+        ]);
+
+        $this->factory->version('123');
+        $resource = new FakeResource(['name' => 'Jonathan']);
+        $response = $this->factory->render('User/Edit', ['user' => $resource]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+    }
+
+    public function test_promise_props_are_resolved(): void
+    {
+        $this->makeRequest(headers: [Header::INERTIA => 'true']);
+
+        $user = (object) ['name' => 'Jonathan'];
+
+        $promise = Mockery::mock(PromiseInterface::class)
+            ->shouldReceive('wait')
+            ->once()
+            ->andReturn($user)
+            ->getMock();
+
+        $this->factory->version('123');
+        $response = $this->factory->render('User/Edit', ['user' => $promise]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']->name);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+    }
+
+    public function test_xhr_partial_response(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'partial',
+        ]);
+
+        $this->factory->version('123');
+        $response = $this->factory->render('User/Edit', [
+            'user' => (object) ['name' => 'Jonathan'],
+            'partial' => 'partial-data',
+        ]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+
+        $this->assertCount(1, $page['props']);
+        $this->assertArrayHasKey('partial', $page['props']);
+        $this->assertSame('partial-data', $page['props']['partial']);
+        $this->assertArrayNotHasKey('user', $page['props']);
+    }
+
+    public function test_exclude_props_from_partial_response(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_EXCEPT => 'user',
+        ]);
+
+        $this->factory->version('123');
+        $response = $this->factory->render('User/Edit', [
+            'user' => (object) ['name' => 'Jonathan'],
+            'partial' => 'partial-data',
+        ]);
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame(ContentType::JSON->value, $response->headers['Content-Type']->values[0]);
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+
+        $this->assertCount(1, $page['props']);
+        $this->assertArrayHasKey('partial', $page['props']);
+        $this->assertSame('partial-data', $page['props']['partial']);
+        $this->assertArrayNotHasKey('user', $page['props']);
+    }
+
+    public function test_nested_partial_props(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'auth.user,auth.shared_value',
+        ]);
+
+        $props = [
+            'auth' => [
+                'user' => new LazyProp(fn() => [
+                    'name' => 'Jonathan Reinink',
+                    'email' => 'jonathan@example.com',
+                ]),
+                'shared_value' => 'value',
+                'value' => 'value',
+            ],
+            'shared' => [
+                'flash' => 'value',
+            ],
+        ];
+
+        $response = $this->factory->render('User/Edit', $props);
+        $page = $response->body;
+
+        $this->assertArrayNotHasKey('shared', $page['props']);
+        $this->assertArrayHasKey('auth', $page['props']);
+        $this->assertArrayNotHasKey('value', $page['props']['auth']);
+        $this->assertSame('Jonathan Reinink', $page['props']['auth']['user']['name']);
+        $this->assertSame('jonathan@example.com', $page['props']['auth']['user']['email']);
+        $this->assertSame('value', $page['props']['auth']['shared_value']);
+    }
+
+    public function test_exclude_nested_props_from_partial_response(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'auth',
+            Header::PARTIAL_EXCEPT => 'auth.user',
+        ]);
+
+        $props = [
+            'auth' => [
+                'user' => new LazyProp(fn() => [
+                    'name' => 'Jonathan Reinink',
+                    'email' => 'jonathan@example.com',
+                ]),
+                'shared_value' => 'value',
+            ],
+            'shared' => [
+                'flash' => 'value',
+            ],
+        ];
+
+        $response = $this->factory->render('User/Edit', $props);
+        $page = $response->body;
+
+        $this->assertArrayNotHasKey('shared', $page['props']);
+        $this->assertArrayHasKey('auth', $page['props']);
+        $this->assertArrayNotHasKey('user', $page['props']['auth']);
+        $this->assertSame('value', $page['props']['auth']['shared_value']);
+    }
+
+    public function test_lazy_props_are_not_included_by_default(): void
+    {
+        $this->makeRequest(
+            uri: '/users',
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
+
+        $lazyProp = new LazyProp(fn() => 'A lazy value');
+
+        $response = $this->factory->render('Users', [
+            'users' => [],
+            'lazy' => $lazyProp,
+        ]);
+
+        $page = $response->body;
+
+        $this->assertSame([], $page['props']['users']);
+        $this->assertArrayNotHasKey('lazy', $page['props']);
+    }
+
+    public function test_lazy_props_are_included_in_partial_reload(): void
+    {
+        $this->makeRequest(
+            uri: '/users',
+            headers: [
+                Header::INERTIA => 'true',
+                Header::PARTIAL_COMPONENT => 'Users',
+                Header::PARTIAL_ONLY => 'lazy',
+            ],
+        );
+
+        $lazyProp = new LazyProp(fn() => 'A lazy value');
+
+        $response = $this->factory->render('Users', [
+            'users' => [],
+            'lazy' => $lazyProp,
+        ]);
+
+        $page = $response->body;
+
+        $this->assertArrayNotHasKey('users', $page['props']);
+        $this->assertSame('A lazy value', $page['props']['lazy']);
+    }
+
+    public function test_defer_arrayable_props_are_resolved_in_partial_reload(): void
+    {
+        $this->makeRequest(
+            uri: '/users',
+            headers: [
+                Header::INERTIA => 'true',
+                Header::PARTIAL_COMPONENT => 'Users',
+                Header::PARTIAL_ONLY => 'defer',
+            ],
+        );
+
+        $deferProp = new DeferProp(function () {
+            return new class implements ArrayableInterface {
+                #[Override]
+                public function toArray(): array
+                {
+                    return ['foo' => 'bar'];
+                }
+            };
+        });
+
+        $response = $this->factory->render('Users', [
+            'users' => [],
+            'defer' => $deferProp,
+        ]);
+
+        $page = $response->body;
+
+        $this->assertArrayNotHasKey('users', $page['props']);
+        $this->assertSame(['foo' => 'bar'], $page['props']['defer']);
+    }
+
+    public function test_always_props_are_included_on_partial_reload(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'data',
+        ]);
+
+        $props = [
+            'user' => new LazyProp(fn() => [
+                'name' => 'Jonathan Reinink',
+                'email' => 'jonathan@example.com',
+            ]),
+            'data' => [
+                'name' => 'Taylor Otwell',
+            ],
+            'errors' => new AlwaysProp(fn() => [
+                'name' => 'The email field is required.',
+            ]),
+        ];
+
+        $response = $this->factory->render('User/Edit', $props);
+        $page = $response->body;
+
+        $this->assertSame('The email field is required.', $page['props']['errors']['name']);
+        $this->assertSame('Taylor Otwell', $page['props']['data']['name']);
+        $this->assertArrayNotHasKey('user', $page['props']);
+    }
+
+    public function test_inertia_responsable_objects(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'responsableProps']),
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $page = $response->body;
+        $props = $page['props'];
+
+        $this->assertSame('bar', $props['foo']);
+        $this->assertSame('qux', $props['baz']);
+        $this->assertSame('corge', $props['quux']);
+    }
+
+    public function test_props_can_be_merged_with_shared_data(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'mergeWithShared']),
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $page = $response->body;
+
+        $props = $page['props'];
+
+        $this->assertSame(['foo', 'bar'], $props['items']);
+        $this->assertSame(['foo', 'baz'], $props['deep']['foo']['bar']);
+    }
+
+    public function test_top_level_dot_props_get_unpacked(): void
+    {
+        $this->makeRequest(
+            uri: '/products/123',
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $props = [
+            'auth' => [
+                'user' => [
+                    'name' => 'Jonathan Reinink',
+                ],
+            ],
+            'auth.user.can' => [
+                'do.stuff' => true,
+            ],
+            'product' => ['name' => 'My example product'],
+        ];
+
+        $response = $this->factory->render('User/Edit', $props);
+        $page = $response->body;
+
+        $user = $page['props']['auth']['user'];
+        $this->assertSame('Jonathan Reinink', $user['name']);
+        $this->assertTrue($user['can']['do.stuff']);
+        $this->assertArrayNotHasKey('auth.user.can', $page['props']);
+    }
+
+    public function test_nested_dot_props_do_not_get_unpacked(): void
+    {
+        $this->makeRequest(
+            uri: '/products/123',
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $props = [
+            'auth' => [
+                'user.can' => [
+                    'do.stuff' => true,
+                ],
+                'user' => [
+                    'name' => 'Jonathan Reinink',
+                ],
+            ],
+            'product' => ['name' => 'My example product'],
+        ];
+
+        $response = $this->factory->render('User/Edit', $props);
+        $page = $response->body;
+
+        $auth = $page['props']['auth'];
+        $this->assertSame('Jonathan Reinink', $auth['user']['name']);
+        $this->assertTrue($auth['user.can']['do.stuff']);
+        $this->assertArrayNotHasKey('can', $auth);
+    }
+
+    public function test_props_can_be_added_using_the_with_method(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'withMethod']),
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $page = $response->body;
+        $props = $page['props'];
+
+        $this->assertSame('bar', $props['foo']);
+        $this->assertSame('qux', $props['baz']);
+        $this->assertSame('corge', $props['quux']);
+        $this->assertSame('garply', $props['grault']);
+    }
+
+    public function test_responsable_with_invalid_key(): void
+    {
+        $this->makeRequest(headers: [Header::INERTIA => 'true']);
+
+        $resource = new FakeResource(["\x00*\x00_invalid_key" => 'for object']);
+
+        $response = $this->factory->render('User/Edit', ['resource' => $resource]);
+        $page = $response->body;
+
+        $this->assertSame(["\x00*\x00_invalid_key" => 'for object'], $page['props']['resource']);
+    }
+
+    public function test_the_page_url_is_prefixed_with_the_proxy_prefix(): void
+    {
+        $this->makeRequest(headers: [Header::FORWARDED_PREFIX => '/sub/directory']);
+
+        $user = ['name' => 'Jonathan'];
+        $response = $this->factory->render('User/Edit', [
+            'user' => $user,
+        ]);
+
+        $page = $response->body->inertia['page'];
+        $resolvedBody = $response->body->jsonSerialize();
+
+        $this->assertInstanceOf(LazyBody::class, $response->body);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(InertiaView::class, $resolvedBody);
+        $this->assertSame('/sub/directory/user/123', $page['url']);
+    }
+
+    public function test_the_page_url_doesnt_double_up(): void
+    {
+        $this->makeRequest(
+            uri: '/subpath/product/122',
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $response = $this->factory->render('Product/Show', []);
+        $page = $response->body;
+
+        $this->assertSame('/subpath/product/122', $page['url']);
+    }
+
+    public function test_trailing_slashes_in_a_url_are_preserved(): void
+    {
+        $this->makeRequest(
+            uri: '/users/',
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $response = $this->factory->render('User/Index', []);
+        $page = $response->body;
+
+        $this->assertSame('/users/', $page['url']);
+    }
+
+    public function test_trailing_slashes_in_a_url_with_query_parameters_are_preserved(): void
+    {
+        $this->makeRequest(
+            uri: '/users/?page=1&sort=name',
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $response = $this->factory->render('User/Index', []);
+        $page = $response->body;
+
+        $this->assertSame('/users/?page=1&sort=name', $page['url']);
+    }
+
+    public function test_a_url_without_trailing_slash_is_resolved_correctly(): void
+    {
+        $this->makeRequest(
+            uri: '/users',
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $response = $this->factory->render('User/Index', []);
+        $page = $response->body;
+
+        $this->assertSame('/users', $page['url']);
+    }
+
+    public function test_a_url_without_trailing_slash_and_query_parameters_is_resolved_correctly(): void
+    {
+        $this->makeRequest(
+            uri: '/users?page=1&sort=name',
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $response = $this->factory->render('User/Index', []);
+        $page = $response->body;
+
+        $this->assertSame('/users?page=1&sort=name', $page['url']);
+    }
 }


### PR DESCRIPTION
This PR adds compatibility updates for Tempest ^2.0 and includes updated tests. I've tested this on a fresh install of `tempest/app` and it works well.