### PR TITLE
breaking: change default pagination format to native

### DIFF
--- a/src/Configs/InertiaConfig.php
+++ b/src/Configs/InertiaConfig.php
@@ -85,9 +85,7 @@ final readonly class InertiaConfig
          * | standard in the Laravel ecosystem and expected by most Inertia.js
          * | front-end pagination components.
          * |
-         * | Set to false to receive the raw PaginatedData object in your props.
-         * |
          */
-        public bool $transform_pagination = true,
+        public bool $transform_pagination = false,
     ) {}
 }

--- a/src/Configs/inertia.config.php
+++ b/src/Configs/inertia.config.php
@@ -11,5 +11,5 @@ return new InertiaConfig(
     ssr: new SsrConfig(),
     pages: new PageConfig(),
     history: new HistoryConfig(),
-    transform_pagination: true,
+    transform_pagination: false,
 );

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use GuzzleHttp\Promise\PromiseInterface;
+use Inertia\Configs\InertiaConfig;
 use Inertia\Contracts\Arrayable;
 use Inertia\LazyBody;
 use Inertia\Props\AlwaysProp;
@@ -491,6 +492,8 @@ class ResponseTest extends TestCase
 
     public function test_lazy_resource_response(): void
     {
+        $this->container->singleton(InertiaConfig::class, fn() => new InertiaConfig(transform_pagination: true));
+
         $this->makeRequest(
             uri: '/users?page=1',
             headers: [
@@ -537,6 +540,8 @@ class ResponseTest extends TestCase
 
     public function test_nested_lazy_resource_response(): void
     {
+        $this->container->singleton(InertiaConfig::class, fn() => new InertiaConfig(transform_pagination: true));
+
         $this->makeRequest(
             uri: '/users?page=1',
             headers: [


### PR DESCRIPTION
This update changes the default pagination behavior. Previously, paginated resources were automatically transformed into Laravel’s pagination format by default. The default is now set to return native pagination data. The behavior can still be changed through the existing configuration option for projects that prefer the Laravel-style pagination format.

**Impact:**

- Projects expecting Laravel-style pagination must update their configuration to maintain the previous behavior.