### PR TITLE
refactor: middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ npm install @inertiajs/svelte
 Update your main JavaScript file to boot your Inertia app.
 
 ```js
-import '../app/main.entrypoint.css'
-
 import { createInertiaApp } from '@inertiajs/vue3'
 import { createApp, h } from 'vue'
 
@@ -115,8 +113,6 @@ void createInertiaApp({
 <summary>React</summary>
 
 ```js
-import '../app/main.entrypoint.css'
-
 import { createInertiaApp } from '@inertiajs/react'
 import { createRoot } from 'react-dom/client'
 
@@ -136,8 +132,6 @@ void createInertiaApp({
 <summary>Svelte</summary>
 
 ```js
-import '../app/main.entrypoint.css'
-
 import { createInertiaApp } from '@inertiajs/svelte'
 import { mount } from 'svelte'
 
@@ -152,27 +146,6 @@ void createInertiaApp({
 })
 ```
 </details>
-
-## Validation Errors
-
-To handle validation errors, flash them to the session using Tempest's `Session::VALIDATION_ERRORS` key. When validation
-fails, redirect back using `Back()`:
-
-```php
-#[Post('/login')]
-public function login(Request $request, Validator $validator, Session $session): Response|Back
-{
-    $failures = $validator->validateValuesForClass(Login::class, $request->body);
-
-    if ($failures !== []) {
-        $session->flash(Session::VALIDATION_ERRORS, $failures);
-
-        return new Back();
-    }
-
-    // ... handle successful login
-}
-```
 
 The adapter will automatically expose these errors under the errors prop on the client side.
 
@@ -229,7 +202,7 @@ To enable SSR, you'll need to configure your front-end build process to generate
 
 ### 1. Update Vite Configuration
 
-Modify your `vite.config.ts` to handle both client and server builds. The `ssrBuild` flag provided by Vite allows you to
+Modify your `vite.config.js` to handle both client and server builds. The `ssrBuild` flag provided by Vite allows you to
 conditionally change the configuration.
 
 ```diff
@@ -240,21 +213,15 @@ conditionally change the configuration.
   import vue from '@vitejs/plugin-vue';
 
 - export default defineConfig({
--     plugins: [
--         tailwindcss(),
--         tempest(),
--         vue(),
--     ],
-- })
-+ export default defineConfig((configEnv: ConfigEnv) => {
++ export default defineConfig((ConfigEnv) => {
 +     const isSsrBuild = configEnv.ssrBuild === true;
 +
 +     return {
-+         plugins: [
-+             tailwindcss(),
-+             tempest(),
-+             vue(),
-+         ],
+          plugins: [
+              tailwindcss(),
+              tempest(),
+              vue(),
+          ],
 +         build: {
 +             outDir: isSsrBuild ? 'ssr' : 'public/build',
 +             manifest: !isSsrBuild ? 'manifest.json' : false,
@@ -267,12 +234,12 @@ conditionally change the configuration.
 +             noExternal: ['@inertiajs/vue3'],
 +         },
 +     };
-+ });
+  });
 ```
 
 ### 2. Create an SSR Entry Point
 
-Create a new file, `app/inertia.ssr.ts` (or `.js`), that will serve as the entry point for your Node.js server. This
+Create a new file, `app/inertia.ssr.js`, that will serve as the entry point for your Node.js server. This
 file is responsible for creating the SSR server. Unlike client-side entrypoints, this file should not include `.entrypoint.` in
 its name. Tempest automatically discovers those for the browser, and this file is meant to stay server-side.
 

--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -17,7 +17,6 @@ use Tempest\Http\Method;
 use Tempest\Http\Request;
 use Tempest\Http\Response;
 use Tempest\Http\Responses\Back;
-use Tempest\Http\Responses\Ok;
 use Tempest\Http\Session\Session;
 use Tempest\Http\Status;
 use Tempest\Router\Exceptions\ControllerActionHadNoReturn;
@@ -111,7 +110,7 @@ class Middleware implements HttpMiddleware
     #[Override]
     public function __invoke(Request $request, HttpMiddlewareCallable $next): Response
     {
-        $this->inertia->version($this->version());
+        $this->inertia->version($this->version(...));
         $this->inertia->share($this->share($request));
         $this->inertia->setRootView($this->rootView());
 
@@ -121,12 +120,12 @@ class Middleware implements HttpMiddleware
 
         try {
             $response = $next($request);
-        } catch (ControllerActionHadNoReturn) {
-            if (!$request->headers->has(Header::INERTIA)) {
-                return new Ok();
+        } catch (ControllerActionHadNoReturn $controllerActionHadNoReturn) {
+            if ($request->headers->has(Header::INERTIA)) {
+                $response = $this->onEmptyResponse();
+            } else {
+                throw $controllerActionHadNoReturn;
             }
-
-            $response = $this->onEmptyResponse();
         }
 
         if ($response->body instanceof LazyBody) {
@@ -145,7 +144,7 @@ class Middleware implements HttpMiddleware
 
         if (
             $request->method === Method::GET
-            && $request->headers->get(Header::VERSION) !== $this->inertia->getVersion()
+            && ($request->headers->get(Header::VERSION) ?? '') !== $this->inertia->getVersion()
         ) {
             $response = $this->onVersionChange($request);
         }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -33,11 +33,6 @@ use function Tempest\invoke;
 final class ResponseFactory
 {
     /**
-     * @var array<string, bool>
-     */
-    private array $componentCache = [];
-
-    /**
      * The name of the root view.
      */
     private string $rootView = 'inertia.view.php';
@@ -68,6 +63,11 @@ final class ResponseFactory
      * The URL resolver callback.
      */
     private ?Closure $urlResolver = null;
+
+    /**
+     * @var array<string, bool>
+     */
+    private array $componentCache = [];
 
     private Session $session {
         get => $this->session ??= get(Session::class);
@@ -152,9 +152,11 @@ final class ResponseFactory
      */
     public function getVersion(): string
     {
-        $version = $this->version instanceof Closure ? invoke($this->version) : $this->version;
+        if ($this->version instanceof Closure) {
+            $this->version = (string) invoke($this->version);
+        }
 
-        return (string) $version;
+        return (string) $this->version;
     }
 
     /**

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -16,6 +16,7 @@ use Tempest\Http\ContentType;
 use Tempest\Http\Request;
 use Tempest\Http\Session\Session;
 use Tempest\Http\Status;
+use Tempest\Router\Exceptions\ControllerActionHadNoReturn;
 use Tempest\Validation\Rules\IsEmail;
 
 use function Tempest\root_path;
@@ -63,16 +64,14 @@ class MiddlewareTest extends TestCase
 
     public function test_no_response_means_no_response_for_non_inertia_requests(): void
     {
-        $response = $this->http->put(
+        $this->expectException(ControllerActionHadNoReturn::class);
+
+        $this->http->put(
             uri: uri([TestController::class, 'voidPutAction']),
             headers: [
                 'Content-Type' => 'application/json',
             ],
         );
-
-        $this->assertTrue(TestController::$voidActionCalled, 'The controller action was not called.');
-        $response->assertStatus(Status::OK);
-        $this->assertEmpty($response->body);
     }
 
     public function test_the_version_is_optional(): void


### PR DESCRIPTION
- The middleware now throws Tempest standard `ControllerActionHadNoReturn` exception instead of silently returning a 200 OK.
- The version check now correctly handles the `null` version during `npm run dev`, preventing the 409 mismatch error.