### PR TITLE
refactor: make Laravel pagination integration optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
   "require": {
     "php": "^8.4",
     "ext-json": "*",
-    "tempest/framework": "^2.4",
-    "illuminate/pagination": "^12.0"
+    "tempest/framework": "^2.4"
   },
   "require-dev": {
     "ext-pdo_sqlite": "*",
@@ -43,6 +42,7 @@
     "rector/rector": "^2.2.5"
   },
   "suggest": {
+    "illuminate/pagination": "Required to transform PaginatedData into a Laravel paginator instance.",
     "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` tempest command."
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "carthage-software/mago": "1.0.0-beta.34",
     "mockery/mockery": "^1.6.12",
     "phpunit/phpunit": "^12.4.1",
-    "rector/rector": "^2.2.5"
+    "rector/rector": "^2.2.5",
+    "illuminate/pagination": "^12.35.1"
   },
   "suggest": {
     "illuminate/pagination": "Required to transform PaginatedData into a Laravel paginator instance.",

--- a/src/Support/PaginatorAdapter.php
+++ b/src/Support/PaginatorAdapter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Inertia\Support;
 
-use Illuminate\Pagination\LengthAwarePaginator;
 use Inertia\Contracts\Arrayable;
 use Override;
 use RuntimeException;
@@ -18,15 +17,17 @@ final readonly class PaginatorAdapter implements Arrayable
         private Request $request,
     ) {}
 
-    public function toIlluminatePaginator(): LengthAwarePaginator
+    public function toIlluminatePaginator(): object
     {
-        if (!class_exists(LengthAwarePaginator::class)) {
+        $laravelPaginatorClass = \Illuminate\Pagination\LengthAwarePaginator::class;
+
+        if (!class_exists($laravelPaginatorClass)) {
             throw new RuntimeException(
                 'Cannot transform to Laravel paginator: package "illuminate/pagination" is not installed.',
             );
         }
 
-        return new LengthAwarePaginator(
+        return new $laravelPaginatorClass(
             items: $this->paginator->data,
             total: $this->paginator->totalItems,
             perPage: $this->paginator->itemsPerPage,

--- a/src/Support/PaginatorAdapter.php
+++ b/src/Support/PaginatorAdapter.php
@@ -7,6 +7,7 @@ namespace Inertia\Support;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Inertia\Contracts\Arrayable;
 use Override;
+use RuntimeException;
 use Tempest\Http\Request;
 use Tempest\Support\Paginator\PaginatedData;
 
@@ -19,6 +20,10 @@ final readonly class PaginatorAdapter implements Arrayable
 
     public function toIlluminatePaginator(): LengthAwarePaginator
     {
+        if (!class_exists(LengthAwarePaginator::class)) {
+            throw new RuntimeException('Cannot transform to Laravel paginator: package "illuminate/pagination" is not installed.');
+        }
+
         return new LengthAwarePaginator(
             items: $this->paginator->data,
             total: $this->paginator->totalItems,

--- a/src/Support/PaginatorAdapter.php
+++ b/src/Support/PaginatorAdapter.php
@@ -21,7 +21,9 @@ final readonly class PaginatorAdapter implements Arrayable
     public function toIlluminatePaginator(): LengthAwarePaginator
     {
         if (!class_exists(LengthAwarePaginator::class)) {
-            throw new RuntimeException('Cannot transform to Laravel paginator: package "illuminate/pagination" is not installed.');
+            throw new RuntimeException(
+                'Cannot transform to Laravel paginator: package "illuminate/pagination" is not installed.',
+            );
         }
 
         return new LengthAwarePaginator(


### PR DESCRIPTION
Removes the hard dependency on `illuminate/pagination`. The adapter now conditionally checks for the presence of `LengthAwarePaginator` and throws a clear runtime exception if the package is not installed.