### PR TITLE
chore: bump dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,11 @@
   },
   "require-dev": {
     "ext-pdo_sqlite": "*",
-    "carthage-software/mago": "1.0.0-rc.7",
+    "carthage-software/mago": "1.0.1",
     "mockery/mockery": "^1.6.12",
-    "phpunit/phpunit": "^12.4.1",
-    "rector/rector": "2.2.11",
-    "illuminate/pagination": "^12.35.1"
+    "phpunit/phpunit": "^12.5.4",
+    "rector/rector": "2.2.14",
+    "illuminate/pagination": "^12.43.1"
   },
   "conflict": {
     "tempest/framework": ">=2.6.0 <=2.7.0"

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,11 @@
   },
   "require-dev": {
     "ext-pdo_sqlite": "*",
-    "carthage-software/mago": "1.0.1",
+    "carthage-software/mago": "1.0.3",
     "mockery/mockery": "^1.6.12",
     "phpunit/phpunit": "^12.5.4",
-    "rector/rector": "2.2.14",
-    "illuminate/pagination": "^12.43.1"
+    "rector/rector": "2.3.0",
+    "illuminate/pagination": "^12.46.0"
   },
   "conflict": {
     "tempest/framework": ">=2.6.0 <=2.7.0"

--- a/mago.toml
+++ b/mago.toml
@@ -6,8 +6,9 @@ includes = ["vendor"]
 excludes = []
 
 [formatter]
-print-width = 120
-null-type-hint = "question"
+space-after-logical-not-unary-prefix-operator = true
+space-before-arrow-function-parameter-list-parenthesis = true
+always-break-named-arguments-list = true
 
 [linter]
 integrations = ["tempest", "phpunit"]

--- a/src/Contracts/IgnoreFirstLoad.php
+++ b/src/Contracts/IgnoreFirstLoad.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Inertia\Contracts;
 
-interface IgnoreFirstLoad
-{
-}
+interface IgnoreFirstLoad {}

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -41,20 +41,12 @@ class Inertia extends Facade
      */
     public static function share(string|array|ArrayInterface $key, mixed $value = null): void
     {
-        static::instance()
-            ->share(
-                key: $key,
-                value: $value,
-            );
+        static::instance()->share(key: $key, value: $value);
     }
 
     public static function getShared(?string $key = null, mixed $default = null): mixed
     {
-        return static::instance()
-            ->getShared(
-                key: $key,
-                default: $default,
-            );
+        return static::instance()->getShared(key: $key, default: $default);
     }
 
     public static function clearHistory(): void
@@ -93,13 +85,7 @@ class Inertia extends Facade
         string $wrapper = 'data',
         ProvidesScrollMetadata|callable|null $metadata = null,
     ): ScrollProp {
-        return static::instance()
-            ->scroll(
-                value: $value,
-                pageName: $pageName,
-                wrapper: $wrapper,
-                metadata: $metadata,
-            );
+        return static::instance()->scroll(value: $value, pageName: $pageName, wrapper: $wrapper, metadata: $metadata);
     }
 
     public static function optional(callable $callback): OptionalProp
@@ -115,11 +101,7 @@ class Inertia extends Facade
 
     public static function defer(callable $callback, string $group = 'default'): DeferProp
     {
-        return static::instance()
-            ->defer(
-                callback: $callback,
-                group: $group,
-            );
+        return static::instance()->defer(callback: $callback, group: $group);
     }
 
     public static function always(mixed $value): AlwaysProp
@@ -142,11 +124,7 @@ class Inertia extends Facade
      */
     public static function render(string $component, array|ArrayInterface $props = []): Response
     {
-        return static::instance()
-            ->render(
-                component: $component,
-                props: $props,
-            );
+        return static::instance()->render(component: $component, props: $props);
     }
 
     public static function location(string|Redirect $url): \Tempest\Http\Response

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -41,12 +41,20 @@ class Inertia extends Facade
      */
     public static function share(string|array|ArrayInterface $key, mixed $value = null): void
     {
-        static::instance()->share(key: $key, value: $value);
+        static::instance()
+            ->share(
+                key: $key,
+                value: $value,
+            );
     }
 
     public static function getShared(?string $key = null, mixed $default = null): mixed
     {
-        return static::instance()->getShared(key: $key, default: $default);
+        return static::instance()
+            ->getShared(
+                key: $key,
+                default: $default,
+            );
     }
 
     public static function clearHistory(): void
@@ -85,7 +93,13 @@ class Inertia extends Facade
         string $wrapper = 'data',
         ProvidesScrollMetadata|callable|null $metadata = null,
     ): ScrollProp {
-        return static::instance()->scroll(value: $value, pageName: $pageName, wrapper: $wrapper, metadata: $metadata);
+        return static::instance()
+            ->scroll(
+                value: $value,
+                pageName: $pageName,
+                wrapper: $wrapper,
+                metadata: $metadata,
+            );
     }
 
     public static function optional(callable $callback): OptionalProp
@@ -101,7 +115,11 @@ class Inertia extends Facade
 
     public static function defer(callable $callback, string $group = 'default'): DeferProp
     {
-        return static::instance()->defer(callback: $callback, group: $group);
+        return static::instance()
+            ->defer(
+                callback: $callback,
+                group: $group,
+            );
     }
 
     public static function always(mixed $value): AlwaysProp
@@ -124,7 +142,11 @@ class Inertia extends Facade
      */
     public static function render(string $component, array|ArrayInterface $props = []): Response
     {
-        return static::instance()->render(component: $component, props: $props);
+        return static::instance()
+            ->render(
+                component: $component,
+                props: $props,
+            );
     }
 
     public static function location(string|Redirect $url): \Tempest\Http\Response

--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -133,10 +133,7 @@ class Middleware implements HttpMiddleware
             $response = $response->setBody($resolvedBody);
         }
 
-        $response = $response->addHeader(
-            key: 'Vary',
-            value: Header::INERTIA,
-        );
+        $response = $response->addHeader(key: 'Vary', value: Header::INERTIA);
 
         if (!$request->headers->has(Header::INERTIA) || $response instanceof InertiaResponse) {
             return $response;

--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -74,11 +74,11 @@ class Middleware implements HttpMiddleware
     {
         return [
             'errors' => $this->inertia->always($this->errorResolver),
-            'auth' => $this->inertia->always(static fn(Authenticator $auth) => [
+            'auth' => $this->inertia->always(static fn (Authenticator $auth) => [
                 'user' => $auth->current(),
             ]),
             'flash' => [
-                'message' => fn() => $this->session->get('message'),
+                'message' => fn () => $this->session->get('message'),
             ],
         ];
     }
@@ -133,9 +133,12 @@ class Middleware implements HttpMiddleware
             $response = $response->setBody($resolvedBody);
         }
 
-        $response = $response->addHeader(key: 'Vary', value: Header::INERTIA);
+        $response = $response->addHeader(
+            key: 'Vary',
+            value: Header::INERTIA,
+        );
 
-        if (!$request->headers->has(Header::INERTIA) || $response instanceof InertiaResponse) {
+        if (! $request->headers->has(Header::INERTIA) || $response instanceof InertiaResponse) {
             return $response;
         }
 

--- a/src/Props/AlwaysProp.php
+++ b/src/Props/AlwaysProp.php
@@ -27,7 +27,7 @@ final readonly class AlwaysProp implements InvokableProp
     #[Override]
     public function __invoke(): mixed
     {
-        if (!is_callable($this->value)) {
+        if (! is_callable($this->value)) {
             return $this->value;
         }
 

--- a/src/Props/ScrollProp.php
+++ b/src/Props/ScrollProp.php
@@ -112,7 +112,10 @@ final class ScrollProp implements Mergeable, InvokableProp
         $value = $this();
 
         if (is_null($this->metadata)) {
-            return ScrollMetadata::fromPaginator(paginator: $value, pageName: $this->pageName);
+            return ScrollMetadata::fromPaginator(
+                paginator: $value,
+                pageName: $this->pageName,
+            );
         }
 
         return ($this->metadata)($value);

--- a/src/Props/ScrollProp.php
+++ b/src/Props/ScrollProp.php
@@ -112,10 +112,7 @@ final class ScrollProp implements Mergeable, InvokableProp
         $value = $this();
 
         if (is_null($this->metadata)) {
-            return ScrollMetadata::fromPaginator(
-                paginator: $value,
-                pageName: $this->pageName,
-            );
+            return ScrollMetadata::fromPaginator(paginator: $value, pageName: $this->pageName);
         }
 
         return ($this->metadata)($value);

--- a/src/Response.php
+++ b/src/Response.php
@@ -208,8 +208,8 @@ final class Response implements HttpResponse
      */
     public function resolvePartialProperties(array $props): array
     {
-        if (!$this->isPartial()) {
-            return array_filter($props, static fn($prop) => !$prop instanceof IgnoreFirstLoad);
+        if (! $this->isPartial()) {
+            return array_filter($props, static fn ($prop) => ! $prop instanceof IgnoreFirstLoad);
         }
 
         $only = $this->parsePartialHeader(Header::PARTIAL_ONLY);
@@ -246,7 +246,7 @@ final class Response implements HttpResponse
      */
     public function resolveAlways(array $props): array
     {
-        $always = array_filter($this->props, static fn($prop) => $prop instanceof AlwaysProp);
+        $always = array_filter($this->props, static fn ($prop) => $prop instanceof AlwaysProp);
 
         return array_merge($always, $props);
     }
@@ -276,13 +276,19 @@ final class Response implements HttpResponse
             };
 
             if ($this->config->laravel_pagination && $value instanceof PaginatedData) {
-                $value = new PaginatorAdapter(paginator: $value, request: $this->request);
+                $value = new PaginatorAdapter(
+                    paginator: $value,
+                    request: $this->request,
+                );
             }
 
             $currentKey = $parentKey ? $parentKey . '.' . $key : $key;
 
             if ($value instanceof ProvidesInertiaProperty) {
-                $value = $value->toInertiaProperty(new PropertyContext(key: $currentKey, props: $props));
+                $value = $value->toInertiaProperty(new PropertyContext(
+                    key: $currentKey,
+                    props: $props,
+                ));
             }
 
             $value = match (true) {
@@ -293,7 +299,11 @@ final class Response implements HttpResponse
             };
 
             if (is_array($value)) {
-                $value = $this->resolvePropertyInstances(props: $value, unpackDotProps: false, parentKey: $currentKey);
+                $value = $this->resolvePropertyInstances(
+                    props: $value,
+                    unpackDotProps: false,
+                    parentKey: $currentKey,
+                );
             }
 
             if ($unpackDotProps && is_string($key) && str_contains($key, '.')) {
@@ -351,12 +361,12 @@ final class Response implements HttpResponse
 
         return Arr\filter(
             $this->props,
-            static fn($prop, $key) => (
+            static fn ($prop, $key) => (
                 $prop instanceof Mergeable
                 && $prop->shouldMerge()
-                && !in_array($key, $resetProps, true)
+                && ! in_array($key, $resetProps, true)
                 && ($onlyProps === [] || in_array($key, $onlyProps, true))
-                && !in_array($key, $exceptProps, true)
+                && ! in_array($key, $exceptProps, true)
             ),
         );
     }
@@ -380,7 +390,7 @@ final class Response implements HttpResponse
                 $deepMergeProps[] = $key;
             }
 
-            if (!$prop->shouldDeepMerge()) {
+            if (! $prop->shouldDeepMerge()) {
                 if ($prop->appendsAtRoot()) {
                     $appendProps[] = $key;
                 } else {
@@ -410,7 +420,7 @@ final class Response implements HttpResponse
                 'deepMergeProps' => $deepMergeProps,
                 'matchPropsOn' => array_values(array_unique($matchPropsOn)),
             ],
-            static fn(array $prop) => $prop !== [],
+            static fn (array $prop) => $prop !== [],
         );
     }
 
@@ -428,7 +438,7 @@ final class Response implements HttpResponse
         $groupedProps = [];
 
         foreach ($this->props as $key => $prop) {
-            if (!$prop instanceof DeferProp) {
+            if (! $prop instanceof DeferProp) {
                 continue;
             }
 
@@ -450,7 +460,7 @@ final class Response implements HttpResponse
         $scrollPropsResult = [];
 
         foreach ($this->getMergePropsForRequest(false) as $key => $prop) {
-            if (!$prop instanceof ScrollProp) {
+            if (! $prop instanceof ScrollProp) {
                 continue;
             }
 
@@ -501,7 +511,7 @@ final class Response implements HttpResponse
      */
     private function resolveBody(array $page): array|null|InertiaView
     {
-        if (!$this->request->headers->has(Header::INERTIA)) {
+        if (! $this->request->headers->has(Header::INERTIA)) {
             $ssr = $this->ssr($page);
 
             return new InertiaView(
@@ -538,7 +548,7 @@ final class Response implements HttpResponse
      */
     private function ssr(array $page): ?SsrResponse
     {
-        if (!$this->config->ssr->enabled) {
+        if (! $this->config->ssr->enabled) {
             return null;
         }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -276,19 +276,13 @@ final class Response implements HttpResponse
             };
 
             if ($this->config->laravel_pagination && $value instanceof PaginatedData) {
-                $value = new PaginatorAdapter(
-                    paginator: $value,
-                    request: $this->request,
-                );
+                $value = new PaginatorAdapter(paginator: $value, request: $this->request);
             }
 
             $currentKey = $parentKey ? $parentKey . '.' . $key : $key;
 
             if ($value instanceof ProvidesInertiaProperty) {
-                $value = $value->toInertiaProperty(new PropertyContext(
-                    key: $currentKey,
-                    props: $props,
-                ));
+                $value = $value->toInertiaProperty(new PropertyContext(key: $currentKey, props: $props));
             }
 
             $value = match (true) {
@@ -299,11 +293,7 @@ final class Response implements HttpResponse
             };
 
             if (is_array($value)) {
-                $value = $this->resolvePropertyInstances(
-                    props: $value,
-                    unpackDotProps: false,
-                    parentKey: $currentKey,
-                );
+                $value = $this->resolvePropertyInstances(props: $value, unpackDotProps: false, parentKey: $currentKey);
             }
 
             if ($unpackDotProps && is_string($key) && str_contains($key, '.')) {

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -241,7 +241,12 @@ final class ResponseFactory
         string $wrapper = 'data',
         ProvidesScrollMetadata|callable|null $metadata = null,
     ): ScrollProp {
-        return new ScrollProp(value: $value, pageName: $pageName, wrapper: $wrapper, metadata: $metadata);
+        return new ScrollProp(
+            value: $value,
+            pageName: $pageName,
+            wrapper: $wrapper,
+            metadata: $metadata,
+        );
     }
 
     /**
@@ -285,7 +290,10 @@ final class ResponseFactory
                 $url = $url->getHeader('Location')->values[0];
             }
 
-            return new GenericResponse(status: Status::CONFLICT, headers: [Header::LOCATION => $url]);
+            return new GenericResponse(
+                status: Status::CONFLICT,
+                headers: [Header::LOCATION => $url],
+            );
         }
 
         return $url instanceof Redirect ? $url : new Redirect($url);
@@ -299,7 +307,7 @@ final class ResponseFactory
     private function findComponentOrFail(string $component): void
     {
         if (isset($this->componentCache[$component])) {
-            if (!$this->componentCache[$component]) {
+            if (! $this->componentCache[$component]) {
                 throw new ComponentNotFoundException($component, $this->config->pages->page_paths);
             }
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -241,12 +241,7 @@ final class ResponseFactory
         string $wrapper = 'data',
         ProvidesScrollMetadata|callable|null $metadata = null,
     ): ScrollProp {
-        return new ScrollProp(
-            value: $value,
-            pageName: $pageName,
-            wrapper: $wrapper,
-            metadata: $metadata,
-        );
+        return new ScrollProp(value: $value, pageName: $pageName, wrapper: $wrapper, metadata: $metadata);
     }
 
     /**
@@ -290,10 +285,7 @@ final class ResponseFactory
                 $url = $url->getHeader('Location')->values[0];
             }
 
-            return new GenericResponse(
-                status: Status::CONFLICT,
-                headers: [Header::LOCATION => $url],
-            );
+            return new GenericResponse(status: Status::CONFLICT, headers: [Header::LOCATION => $url]);
         }
 
         return $url instanceof Redirect ? $url : new Redirect($url);

--- a/src/Ssr/BundleDetector.php
+++ b/src/Ssr/BundleDetector.php
@@ -26,6 +26,6 @@ final class BundleDetector
             root_path('ssr/inertia.ssr.js'),
         ];
 
-        return array_find($potentialPaths, static fn($path) => $path && file_exists($path));
+        return array_find($potentialPaths, static fn ($path) => $path && file_exists($path));
     }
 }

--- a/src/Ssr/Commands/CheckSsr.php
+++ b/src/Ssr/Commands/CheckSsr.php
@@ -24,8 +24,8 @@ final readonly class CheckSsr
     #[ConsoleCommand(name: 'inertia:check-ssr', description: 'Check the Inertia SSR server health status')]
     public function __invoke(bool $silent = false): ExitCode|int
     {
-        if (!$this->gateway instanceof HasHealthCheck) {
-            if (!$silent) {
+        if (! $this->gateway instanceof HasHealthCheck) {
+            if (! $silent) {
                 $this->console->error('The SSR gateway does not support health checks.');
             }
 
@@ -33,14 +33,14 @@ final readonly class CheckSsr
         }
 
         if ($this->gateway->isHealthy()) {
-            if (!$silent) {
+            if (! $silent) {
                 $this->console->info('Inertia SSR server is running.');
             }
 
             return ExitCode::SUCCESS;
         }
 
-        if (!$silent) {
+        if (! $silent) {
             $this->console->error('Inertia SSR server is not running.');
         }
 

--- a/src/Ssr/Commands/StartSsr.php
+++ b/src/Ssr/Commands/StartSsr.php
@@ -30,7 +30,7 @@ final readonly class StartSsr
     #[ConsoleCommand(name: 'inertia:start-ssr', description: 'Start the Inertia SSR server')]
     public function __invoke(string $runtime = 'node'): ExitCode|int
     {
-        if (!$this->config->ssr->enabled) {
+        if (! $this->config->ssr->enabled) {
             $this->console->error('Inertia SSR is not enabled. Enable it via the `inertia.ssr.enabled` config option.');
 
             return ExitCode::ERROR;
@@ -54,7 +54,7 @@ final readonly class StartSsr
             $this->console->warning('Using a default bundle instead: "' . $bundle . '"');
         }
 
-        if (!in_array($runtime, ['node', 'bun'], true)) {
+        if (! in_array($runtime, ['node', 'bun'], true)) {
             $this->console->error('Unsupported runtime: "' . $runtime . '". Supported runtimes are `node` and `bun`.');
 
             return ExitCode::ERROR;

--- a/src/Ssr/Commands/StopSsr.php
+++ b/src/Ssr/Commands/StopSsr.php
@@ -28,7 +28,7 @@ final readonly class StopSsr
     public function __invoke(bool $silent = false): ExitCode|int
     {
         if (($this->checkSsrCommand)(silent: true)->value === ExitCode::ERROR->value) {
-            if (!$silent) {
+            if (! $silent) {
                 $this->console->error("Inertia SSR server isn't running.");
             }
 
@@ -48,7 +48,7 @@ final readonly class StopSsr
             usleep(200000);
 
             if (($this->checkSsrCommand)(silent: true)->value === ExitCode::ERROR->value) {
-                if (!$silent) {
+                if (! $silent) {
                     $this->console->info('Inertia SSR server stopped successfully.');
                 }
 
@@ -56,7 +56,7 @@ final readonly class StopSsr
             }
         }
 
-        if (!$silent) {
+        if (! $silent) {
             $this->console->error('Failed to stop the Inertia SSR server.');
         }
 

--- a/src/Ssr/Exceptions/SsrException.php
+++ b/src/Ssr/Exceptions/SsrException.php
@@ -6,6 +6,4 @@ namespace Inertia\Ssr\Exceptions;
 
 use Exception;
 
-class SsrException extends Exception
-{
-}
+class SsrException extends Exception {}

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -30,7 +30,7 @@ final readonly class HttpGateway implements Gateway, HasHealthCheck
     #[Override]
     public function dispatch(array $page): ?Response
     {
-        if (!$this->shouldDispatch()) {
+        if (! $this->shouldDispatch()) {
             return null;
         }
 
@@ -41,7 +41,7 @@ final readonly class HttpGateway implements Gateway, HasHealthCheck
                 body: json_encode($page),
             );
 
-            if (!$response->isSuccessful()) {
+            if (! $response->isSuccessful()) {
                 throw new Exception('SSR request failed.');
             }
 
@@ -83,7 +83,7 @@ final readonly class HttpGateway implements Gateway, HasHealthCheck
     {
         return (
             $this->config->ssr->enabled
-            && (!$this->config->ssr->ensure_bundle_exists || $this->bundleDetector->detect() !== null)
+            && (! $this->config->ssr->ensure_bundle_exists || $this->bundleDetector->detect() !== null)
         );
     }
 

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -10,7 +10,6 @@ use Inertia\Ssr\Contracts\Gateway;
 use Inertia\Ssr\Contracts\HasHealthCheck;
 use Override;
 use Tempest\HttpClient\HttpClient;
-use Tempest\Router\Exceptions\ControllerActionHadNoReturn;
 use Tempest\Router\Exceptions\MatchedRouteCouldNotBeResolved;
 use Tempest\Support\Str;
 use Throwable;

--- a/src/Support/Facade.php
+++ b/src/Support/Facade.php
@@ -26,7 +26,7 @@ abstract class Facade
     {
         $instance = static::getFacadeRoot();
 
-        if (!$instance) {
+        if (! $instance) {
             throw new RuntimeException('A facade root has not been set.');
         }
 

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Inertia\Support\Arr;
 
-if (!function_exists(__NAMESPACE__ . '\forget_keys')) {
+if (! function_exists(__NAMESPACE__ . '\forget_keys')) {
     /**
      * Removes the specified keys from the array using dot notation. The array is mutated.
      */
@@ -15,11 +15,11 @@ if (!function_exists(__NAMESPACE__ . '\forget_keys')) {
             $target = &$array;
 
             foreach (array_slice($parts, 0, -1) as $part) {
-                if (!isset($target[$part])) {
+                if (! isset($target[$part])) {
                     continue 2;
                 }
 
-                if (!is_array($target[$part])) {
+                if (! is_array($target[$part])) {
                     continue 2;
                 }
 

--- a/src/Support/PaginatorAdapter.php
+++ b/src/Support/PaginatorAdapter.php
@@ -21,7 +21,7 @@ final readonly class PaginatorAdapter implements Arrayable
     {
         $laravelPaginatorClass = \Illuminate\Pagination\LengthAwarePaginator::class;
 
-        if (!class_exists($laravelPaginatorClass)) {
+        if (! class_exists($laravelPaginatorClass)) {
             throw new RuntimeException(
                 'Cannot transform to Laravel paginator: package "illuminate/pagination" is not installed.',
             );

--- a/src/Support/ResolveErrorProps.php
+++ b/src/Support/ResolveErrorProps.php
@@ -28,7 +28,7 @@ final readonly class ResolveErrorProps
             $fieldName = $this->config->validation->localize_fields ? $key : null;
 
             $messages = arr($rules)->map(
-                fn(Rule $rule) => $this->validator->getErrorMessage($rule, $fieldName),
+                fn (Rule $rule) => $this->validator->getErrorMessage($rule, $fieldName),
             )->toArray();
 
             if ($this->config->validation->multiple_errors) {

--- a/src/Traits/MergesProps.php
+++ b/src/Traits/MergesProps.php
@@ -113,7 +113,7 @@ trait MergesProps
      */
     public function prependsAtRoot(): bool
     {
-        return !$this->append && $this->mergesAtRoot();
+        return ! $this->append && $this->mergesAtRoot();
     }
 
     /**
@@ -134,7 +134,7 @@ trait MergesProps
         match (true) {
             is_bool($path) => $this->append = $path,
             is_string($path) => $this->appendsAtPaths[] = $path,
-            is_array($path) => array_walk($path, fn($value, $key) => is_numeric($key)
+            is_array($path) => array_walk($path, fn ($value, $key) => is_numeric($key)
                 ? $this->append($value)
                 : $this->append($key, $value)),
         };
@@ -154,9 +154,9 @@ trait MergesProps
     public function prepend(bool|string|array $path = true, ?string $matchOn = null): static
     {
         match (true) {
-            is_bool($path) => $this->append = !$path,
+            is_bool($path) => $this->append = ! $path,
             is_string($path) => $this->prependsAtPaths[] = $path,
-            is_array($path) => array_walk($path, fn($value, $key) => is_numeric($key)
+            is_array($path) => array_walk($path, fn ($value, $key) => is_numeric($key)
                 ? $this->prepend($value)
                 : $this->prepend($key, $value)),
         };

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -8,7 +8,7 @@ use Tempest\Support\Arr\ArrayInterface;
 
 use function Tempest\get;
 
-if (!function_exists('inertia')) {
+if (! function_exists('inertia')) {
     function inertia(?string $component = null, array|ArrayInterface $props = []): Response|ResponseFactory
     {
         $instance = get(ResponseFactory::class);
@@ -21,7 +21,7 @@ if (!function_exists('inertia')) {
     }
 }
 
-if (!function_exists('inertia_location')) {
+if (! function_exists('inertia_location')) {
     function inertia_location(string $url): Response
     {
         return get(ResponseFactory::class)->location($url);

--- a/tests/Fixtures/ExampleMiddleware.php
+++ b/tests/Fixtures/ExampleMiddleware.php
@@ -34,7 +34,7 @@ final class ExampleMiddleware extends Middleware
     #[Override]
     public function urlResolver(): ?Closure
     {
-        return static fn() => '/my-custom-url';
+        return static fn () => '/my-custom-url';
     }
 
     #[Override]
@@ -51,7 +51,7 @@ final class ExampleMiddleware extends Middleware
         return [
             ...parent::share($request),
             'flash' => [
-                'message' => static fn() => $request->getCookie('massage'),
+                'message' => static fn () => $request->getCookie('massage'),
             ],
         ];
     }

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -38,7 +38,7 @@ final class TestController
     #[Get('/version-test-with-helper', middleware: [ExampleMiddleware::class])]
     public function versionCanBeAClosure(): Response
     {
-        inertia()->version(static fn() => 'test-version-from-closure');
+        inertia()->version(static fn () => 'test-version-from-closure');
 
         return inertia()->render('User/Edit', [
             'foo' => 'bar',
@@ -48,7 +48,7 @@ final class TestController
     #[Get('/custom-url-resolver')]
     public function customUrlResolver(): Response
     {
-        inertia()->resolveUrlUsing(static fn() => '/my-custom-url');
+        inertia()->resolveUrlUsing(static fn () => '/my-custom-url');
 
         return inertia()->render('User/Edit');
     }
@@ -76,7 +76,7 @@ final class TestController
     #[Get('/shared-closure-test')]
     public function sharedClosure(): Response
     {
-        inertia()->share('query', static fn(Request $request) => $request->query);
+        inertia()->share('query', static fn (Request $request) => $request->query);
 
         return inertia()->render('User/Edit');
     }
@@ -84,7 +84,7 @@ final class TestController
     #[Get('/dot-prop-callbacks-merging-test')]
     public function dotPropsWithCallbacksMerging(): Response
     {
-        inertia()->share('auth.user', static fn() => [
+        inertia()->share('auth.user', static fn () => [
             'name' => 'Jonathan',
         ]);
 

--- a/tests/Integration/AlwaysPropTest.php
+++ b/tests/Integration/AlwaysPropTest.php
@@ -10,7 +10,7 @@ final class AlwaysPropTest extends TestCase
 {
     public function test_can_invoke(): void
     {
-        $alwaysProp = new AlwaysProp(static fn(): string => 'An always value');
+        $alwaysProp = new AlwaysProp(static fn (): string => 'An always value');
 
         $this->assertSame('An always value', $alwaysProp());
     }
@@ -38,7 +38,7 @@ final class AlwaysPropTest extends TestCase
 
     public function test_can_resolve_bindings_when_invoked(): void
     {
-        $alwaysProp = new AlwaysProp(static fn(Request $request): Request => $request);
+        $alwaysProp = new AlwaysProp(static fn (Request $request): Request => $request);
 
         $this->assertInstanceOf(Request::class, $alwaysProp());
     }

--- a/tests/Integration/DeepMergePropTest.php
+++ b/tests/Integration/DeepMergePropTest.php
@@ -12,7 +12,7 @@ final class DeepMergePropTest extends TestCase
 {
     public function test_can_invoke_with_a_callback(): void
     {
-        $mergeProp = new MergeProp(static fn(): string => 'A merge prop value')->deepMerge();
+        $mergeProp = new MergeProp(static fn (): string => 'A merge prop value')->deepMerge();
 
         $this->assertSame('A merge prop value', $mergeProp());
     }
@@ -26,7 +26,7 @@ final class DeepMergePropTest extends TestCase
 
     public function test_can_resolve_bindings_when_invoked(): void
     {
-        $mergeProp = new MergeProp(static fn(Request $request): Request => $request)->deepMerge();
+        $mergeProp = new MergeProp(static fn (Request $request): Request => $request)->deepMerge();
 
         $this->assertInstanceOf(Request::class, $mergeProp());
     }

--- a/tests/Integration/DeferPropTest.php
+++ b/tests/Integration/DeferPropTest.php
@@ -12,7 +12,7 @@ final class DeferPropTest extends TestCase
 {
     public function test_can_invoke(): void
     {
-        $deferProp = new DeferProp(static fn(): string => 'A deferred value', 'default');
+        $deferProp = new DeferProp(static fn (): string => 'A deferred value', 'default');
 
         $this->assertSame('A deferred value', $deferProp());
         $this->assertSame('default', $deferProp->group());
@@ -20,14 +20,14 @@ final class DeferPropTest extends TestCase
 
     public function test_can_invoke_and_merge(): void
     {
-        $deferProp = new DeferProp(static fn(): string => 'A deferred value')->merge();
+        $deferProp = new DeferProp(static fn (): string => 'A deferred value')->merge();
 
         $this->assertSame('A deferred value', $deferProp());
     }
 
     public function test_can_resolve_bindings_when_invoked(): void
     {
-        $deferProp = new DeferProp(static fn(Request $request): Request => $request);
+        $deferProp = new DeferProp(static fn (Request $request): Request => $request);
 
         $this->assertInstanceOf(Request::class, $deferProp());
     }

--- a/tests/Integration/DirectiveTest.php
+++ b/tests/Integration/DirectiveTest.php
@@ -33,10 +33,13 @@ final class DirectiveTest extends TestCase
 
     public function test_inertia_directive_renders_the_root_element_and_script_element(): void
     {
-        $this->container->singleton(InertiaConfig::class, static fn() => new InertiaConfig(
-            ssr: new SsrConfig(enabled: false),
-            pages: new PageConfig(use_script_element_for_initial_page: true),
-        ));
+        $this->container->singleton(
+            InertiaConfig::class,
+            static fn() => new InertiaConfig(
+                ssr: new SsrConfig(enabled: false),
+                pages: new PageConfig(use_script_element_for_initial_page: true),
+            ),
+        );
 
         $response = $this->factory->render('Foo/Bar', self::EXAMPLE_PAGE_OBJECT['props']);
         $view = $response->body;
@@ -56,10 +59,7 @@ final class DirectiveTest extends TestCase
             static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true)),
         );
 
-        $ssrResponse = new Response(
-            head: '<title>SSR Head</title>',
-            body: '<p>This is some example SSR content</p>',
-        );
+        $ssrResponse = new Response(head: '<title>SSR Head</title>', body: '<p>This is some example SSR content</p>');
         $mockGateway = Mockery::mock(Gateway::class)
             ->shouldReceive('dispatch')
             ->once()
@@ -91,10 +91,13 @@ final class DirectiveTest extends TestCase
 
     public function test_inertia_directive_can_use_a_different_root_element_id_when_using_script_element(): void
     {
-        $this->container->singleton(InertiaConfig::class, static fn() => new InertiaConfig(
-            ssr: new SsrConfig(enabled: false),
-            pages: new PageConfig(use_script_element_for_initial_page: true),
-        ));
+        $this->container->singleton(
+            InertiaConfig::class,
+            static fn() => new InertiaConfig(
+                ssr: new SsrConfig(enabled: false),
+                pages: new PageConfig(use_script_element_for_initial_page: true),
+            ),
+        );
 
         $response = $this->factory->render('Foo/Bar', self::EXAMPLE_PAGE_OBJECT['props']);
         $view = $response->body;

--- a/tests/Integration/DirectiveTest.php
+++ b/tests/Integration/DirectiveTest.php
@@ -33,13 +33,10 @@ final class DirectiveTest extends TestCase
 
     public function test_inertia_directive_renders_the_root_element_and_script_element(): void
     {
-        $this->container->singleton(
-            InertiaConfig::class,
-            static fn() => new InertiaConfig(
-                ssr: new SsrConfig(enabled: false),
-                pages: new PageConfig(use_script_element_for_initial_page: true),
-            ),
-        );
+        $this->container->singleton(InertiaConfig::class, static fn () => new InertiaConfig(
+            ssr: new SsrConfig(enabled: false),
+            pages: new PageConfig(use_script_element_for_initial_page: true),
+        ));
 
         $response = $this->factory->render('Foo/Bar', self::EXAMPLE_PAGE_OBJECT['props']);
         $view = $response->body;
@@ -56,16 +53,19 @@ final class DirectiveTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true)),
+            static fn () => new InertiaConfig(ssr: new SsrConfig(enabled: true)),
         );
 
-        $ssrResponse = new Response(head: '<title>SSR Head</title>', body: '<p>This is some example SSR content</p>');
+        $ssrResponse = new Response(
+            head: '<title>SSR Head</title>',
+            body: '<p>This is some example SSR content</p>',
+        );
         $mockGateway = Mockery::mock(Gateway::class)
             ->shouldReceive('dispatch')
             ->once()
             ->andReturn($ssrResponse)
             ->getMock();
-        $this->container->singleton(Gateway::class, static fn() => $mockGateway);
+        $this->container->singleton(Gateway::class, static fn () => $mockGateway);
 
         $response = $this->factory->render('User/Edit', self::EXAMPLE_PAGE_OBJECT['props']);
         $renderedHtml = (string) $response->body->inertia();
@@ -77,7 +77,7 @@ final class DirectiveTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: false)),
+            static fn () => new InertiaConfig(ssr: new SsrConfig(enabled: false)),
         );
 
         $response = $this->factory->render('Foo/Bar', self::EXAMPLE_PAGE_OBJECT['props']);
@@ -91,13 +91,10 @@ final class DirectiveTest extends TestCase
 
     public function test_inertia_directive_can_use_a_different_root_element_id_when_using_script_element(): void
     {
-        $this->container->singleton(
-            InertiaConfig::class,
-            static fn() => new InertiaConfig(
-                ssr: new SsrConfig(enabled: false),
-                pages: new PageConfig(use_script_element_for_initial_page: true),
-            ),
-        );
+        $this->container->singleton(InertiaConfig::class, static fn () => new InertiaConfig(
+            ssr: new SsrConfig(enabled: false),
+            pages: new PageConfig(use_script_element_for_initial_page: true),
+        ));
 
         $response = $this->factory->render('Foo/Bar', self::EXAMPLE_PAGE_OBJECT['props']);
         $view = $response->body;
@@ -138,11 +135,11 @@ final class DirectiveTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true)),
+            static fn () => new InertiaConfig(ssr: new SsrConfig(enabled: true)),
         );
 
         $gateway = new FakeGateway();
-        $this->container->singleton(Gateway::class, static fn() => $gateway);
+        $this->container->singleton(Gateway::class, static fn () => $gateway);
 
         $response = $this->factory->render('User/Edit', self::EXAMPLE_PAGE_OBJECT['props']);
 

--- a/tests/Integration/HistoryTest.php
+++ b/tests/Integration/HistoryTest.php
@@ -16,12 +16,9 @@ final class HistoryTest extends TestCase
 {
     public function test_the_history_is_not_encrypted_or_cleared_by_default(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'basicRenderWithMiddleware']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -32,12 +29,9 @@ final class HistoryTest extends TestCase
 
     public function test_the_history_can_be_encrypted(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'encryptHistory']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'encryptHistory']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -47,12 +41,9 @@ final class HistoryTest extends TestCase
 
     public function test_the_history_can_be_encrypted_via_middleware(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'encryptHistoryWithMiddleware']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'encryptHistoryWithMiddleware']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -67,12 +58,9 @@ final class HistoryTest extends TestCase
             static fn() => new InertiaConfig(history: new HistoryConfig(encrypt: true)),
         );
 
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'basicRenderWithMiddleware']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -87,12 +75,9 @@ final class HistoryTest extends TestCase
             static fn() => new InertiaConfig(history: new HistoryConfig(encrypt: true)),
         );
 
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'encryptHistoryOverride']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'encryptHistoryOverride']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -102,12 +87,9 @@ final class HistoryTest extends TestCase
 
     public function test_the_history_can_be_cleared(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'clearHistory']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'clearHistory']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -117,19 +99,13 @@ final class HistoryTest extends TestCase
 
     public function test_the_history_can_be_cleared_when_redirecting(): void
     {
-        $this->http->get(
-            uri: uri([TestController::class, 'clearHistoryAndRedirect']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $this->http->get(uri: uri([TestController::class, 'clearHistoryAndRedirect']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'basicRender']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'basicRender']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 

--- a/tests/Integration/HistoryTest.php
+++ b/tests/Integration/HistoryTest.php
@@ -16,9 +16,12 @@ final class HistoryTest extends TestCase
 {
     public function test_the_history_is_not_encrypted_or_cleared_by_default(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRenderWithMiddleware']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -29,9 +32,12 @@ final class HistoryTest extends TestCase
 
     public function test_the_history_can_be_encrypted(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'encryptHistory']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'encryptHistory']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -41,9 +47,12 @@ final class HistoryTest extends TestCase
 
     public function test_the_history_can_be_encrypted_via_middleware(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'encryptHistoryWithMiddleware']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'encryptHistoryWithMiddleware']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -55,12 +64,15 @@ final class HistoryTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(history: new HistoryConfig(encrypt: true)),
+            static fn () => new InertiaConfig(history: new HistoryConfig(encrypt: true)),
         );
 
-        $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithMiddleware']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRenderWithMiddleware']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -72,12 +84,15 @@ final class HistoryTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(history: new HistoryConfig(encrypt: true)),
+            static fn () => new InertiaConfig(history: new HistoryConfig(encrypt: true)),
         );
 
-        $response = $this->http->get(uri: uri([TestController::class, 'encryptHistoryOverride']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'encryptHistoryOverride']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -87,9 +102,12 @@ final class HistoryTest extends TestCase
 
     public function test_the_history_can_be_cleared(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'clearHistory']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'clearHistory']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -99,13 +117,19 @@ final class HistoryTest extends TestCase
 
     public function test_the_history_can_be_cleared_when_redirecting(): void
     {
-        $this->http->get(uri: uri([TestController::class, 'clearHistoryAndRedirect']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $this->http->get(
+            uri: uri([TestController::class, 'clearHistoryAndRedirect']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
-        $response = $this->http->get(uri: uri([TestController::class, 'basicRender']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRender']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 

--- a/tests/Integration/HttpGatewayTest.php
+++ b/tests/Integration/HttpGatewayTest.php
@@ -22,7 +22,7 @@ final class HttpGatewayTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: false)),
+            static fn () => new InertiaConfig(ssr: new SsrConfig(enabled: false)),
         );
 
         $gateway = $this->container->get(HttpGateway::class);
@@ -35,7 +35,10 @@ final class HttpGatewayTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true, bundle: null)),
+            static fn () => new InertiaConfig(ssr: new SsrConfig(
+                enabled: true,
+                bundle: null,
+            )),
         );
 
         $gateway = $this->container->get(HttpGateway::class);
@@ -51,13 +54,19 @@ final class HttpGatewayTest extends TestCase
 
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true, bundle: $bundlePath)),
+            static fn () => new InertiaConfig(ssr: new SsrConfig(
+                enabled: true,
+                bundle: $bundlePath,
+            )),
         );
 
-        $fakeResponse = new FakeClientResponse(body: json_encode([
-            'head' => ['<title>SSR Test</title>', '<style></style>'],
-            'body' => '<div id="app">SSR Response</div>',
-        ]), isSuccess: true);
+        $fakeResponse = new FakeClientResponse(
+            body: json_encode([
+                'head' => ['<title>SSR Test</title>', '<style></style>'],
+                'body' => '<div id="app">SSR Response</div>',
+            ]),
+            isSuccess: true,
+        );
 
         $mockClient = Mockery::mock(HttpClient::class)
             ->shouldReceive('post')
@@ -65,7 +74,7 @@ final class HttpGatewayTest extends TestCase
             ->andReturn($fakeResponse)
             ->getMock();
 
-        $this->container->singleton(HttpClient::class, static fn() => $mockClient);
+        $this->container->singleton(HttpClient::class, static fn () => $mockClient);
 
         try {
             $gateway = $this->container->get(HttpGateway::class);
@@ -86,10 +95,16 @@ final class HttpGatewayTest extends TestCase
 
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true, bundle: $bundlePath)),
+            static fn () => new InertiaConfig(ssr: new SsrConfig(
+                enabled: true,
+                bundle: $bundlePath,
+            )),
         );
 
-        $fakeResponse = new FakeClientResponse(body: '', isSuccess: false);
+        $fakeResponse = new FakeClientResponse(
+            body: '',
+            isSuccess: false,
+        );
 
         $mockClient = Mockery::mock(HttpClient::class)
             ->shouldReceive('post')
@@ -97,7 +112,7 @@ final class HttpGatewayTest extends TestCase
             ->andReturn($fakeResponse)
             ->getMock();
 
-        $this->container->singleton(HttpClient::class, static fn() => $mockClient);
+        $this->container->singleton(HttpClient::class, static fn () => $mockClient);
 
         try {
             $gateway = $this->container->get(HttpGateway::class);
@@ -116,10 +131,16 @@ final class HttpGatewayTest extends TestCase
 
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true, bundle: $bundlePath)),
+            static fn () => new InertiaConfig(ssr: new SsrConfig(
+                enabled: true,
+                bundle: $bundlePath,
+            )),
         );
 
-        $fakeResponse = new FakeClientResponse(body: 'invalid json', isSuccess: true);
+        $fakeResponse = new FakeClientResponse(
+            body: 'invalid json',
+            isSuccess: true,
+        );
 
         $mockClient = Mockery::mock(HttpClient::class)
             ->shouldReceive('post')
@@ -127,7 +148,7 @@ final class HttpGatewayTest extends TestCase
             ->andReturn($fakeResponse)
             ->getMock();
 
-        $this->container->singleton(HttpClient::class, static fn() => $mockClient);
+        $this->container->singleton(HttpClient::class, static fn () => $mockClient);
 
         try {
             $gateway = $this->container->get(HttpGateway::class);
@@ -141,8 +162,14 @@ final class HttpGatewayTest extends TestCase
 
     public function test_health_check_the_ssr_server(): void
     {
-        $successResponse = new FakeClientResponse(body: '', isSuccess: true);
-        $failureResponse = new FakeClientResponse(body: '', isSuccess: false);
+        $successResponse = new FakeClientResponse(
+            body: '',
+            isSuccess: true,
+        );
+        $failureResponse = new FakeClientResponse(
+            body: '',
+            isSuccess: false,
+        );
 
         $mockClient = Mockery::mock(HttpClient::class)
             ->shouldReceive('get')
@@ -150,11 +177,11 @@ final class HttpGatewayTest extends TestCase
             ->andReturn(
                 $successResponse,
                 $failureResponse,
-                Mockery::on(static fn() => throw new RuntimeException('Connection refused')),
+                Mockery::on(static fn () => throw new RuntimeException('Connection refused')),
             )
             ->getMock();
 
-        $this->container->singleton(HttpClient::class, static fn() => $mockClient);
+        $this->container->singleton(HttpClient::class, static fn () => $mockClient);
 
         $gateway = $this->container->get(HttpGateway::class);
         $this->assertInstanceOf(HttpGateway::class, $gateway);

--- a/tests/Integration/HttpGatewayTest.php
+++ b/tests/Integration/HttpGatewayTest.php
@@ -35,10 +35,7 @@ final class HttpGatewayTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(
-                enabled: true,
-                bundle: null,
-            )),
+            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true, bundle: null)),
         );
 
         $gateway = $this->container->get(HttpGateway::class);
@@ -54,19 +51,13 @@ final class HttpGatewayTest extends TestCase
 
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(
-                enabled: true,
-                bundle: $bundlePath,
-            )),
+            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true, bundle: $bundlePath)),
         );
 
-        $fakeResponse = new FakeClientResponse(
-            body: json_encode([
-                'head' => ['<title>SSR Test</title>', '<style></style>'],
-                'body' => '<div id="app">SSR Response</div>',
-            ]),
-            isSuccess: true,
-        );
+        $fakeResponse = new FakeClientResponse(body: json_encode([
+            'head' => ['<title>SSR Test</title>', '<style></style>'],
+            'body' => '<div id="app">SSR Response</div>',
+        ]), isSuccess: true);
 
         $mockClient = Mockery::mock(HttpClient::class)
             ->shouldReceive('post')
@@ -95,16 +86,10 @@ final class HttpGatewayTest extends TestCase
 
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(
-                enabled: true,
-                bundle: $bundlePath,
-            )),
+            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true, bundle: $bundlePath)),
         );
 
-        $fakeResponse = new FakeClientResponse(
-            body: '',
-            isSuccess: false,
-        );
+        $fakeResponse = new FakeClientResponse(body: '', isSuccess: false);
 
         $mockClient = Mockery::mock(HttpClient::class)
             ->shouldReceive('post')
@@ -131,16 +116,10 @@ final class HttpGatewayTest extends TestCase
 
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(ssr: new SsrConfig(
-                enabled: true,
-                bundle: $bundlePath,
-            )),
+            static fn() => new InertiaConfig(ssr: new SsrConfig(enabled: true, bundle: $bundlePath)),
         );
 
-        $fakeResponse = new FakeClientResponse(
-            body: 'invalid json',
-            isSuccess: true,
-        );
+        $fakeResponse = new FakeClientResponse(body: 'invalid json', isSuccess: true);
 
         $mockClient = Mockery::mock(HttpClient::class)
             ->shouldReceive('post')
@@ -162,14 +141,8 @@ final class HttpGatewayTest extends TestCase
 
     public function test_health_check_the_ssr_server(): void
     {
-        $successResponse = new FakeClientResponse(
-            body: '',
-            isSuccess: true,
-        );
-        $failureResponse = new FakeClientResponse(
-            body: '',
-            isSuccess: false,
-        );
+        $successResponse = new FakeClientResponse(body: '', isSuccess: true);
+        $failureResponse = new FakeClientResponse(body: '', isSuccess: false);
 
         $mockClient = Mockery::mock(HttpClient::class)
             ->shouldReceive('get')
@@ -177,7 +150,7 @@ final class HttpGatewayTest extends TestCase
             ->andReturn(
                 $successResponse,
                 $failureResponse,
-                Mockery::on(fn() => throw new RuntimeException('Connection refused')),
+                Mockery::on(static fn() => throw new RuntimeException('Connection refused')),
             )
             ->getMock();
 

--- a/tests/Integration/LazyPropTest.php
+++ b/tests/Integration/LazyPropTest.php
@@ -12,14 +12,14 @@ final class LazyPropTest extends TestCase
 {
     public function test_can_invoke(): void
     {
-        $lazyProp = new LazyProp(static fn(): string => 'A lazy value');
+        $lazyProp = new LazyProp(static fn (): string => 'A lazy value');
 
         $this->assertSame('A lazy value', $lazyProp());
     }
 
     public function test_can_resolve_bindings_when_invoked(): void
     {
-        $lazyProp = new LazyProp(static fn(Request $request): Request => $request);
+        $lazyProp = new LazyProp(static fn (Request $request): Request => $request);
 
         $this->assertInstanceOf(Request::class, $lazyProp());
     }

--- a/tests/Integration/MergePropTest.php
+++ b/tests/Integration/MergePropTest.php
@@ -12,7 +12,7 @@ final class MergePropTest extends TestCase
 {
     public function test_can_invoke_with_a_callback(): void
     {
-        $mergeProp = new MergeProp(static fn(): string => 'A merge prop value');
+        $mergeProp = new MergeProp(static fn (): string => 'A merge prop value');
 
         $this->assertSame('A merge prop value', $mergeProp());
     }
@@ -26,7 +26,7 @@ final class MergePropTest extends TestCase
 
     public function test_can_resolve_bindings_when_invoked(): void
     {
-        $mergeProp = new MergeProp(static fn(Request $request): Request => $request);
+        $mergeProp = new MergeProp(static fn (Request $request): Request => $request);
 
         $this->assertInstanceOf(Request::class, $mergeProp());
     }

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -36,11 +36,14 @@ final class MiddlewareTest extends TestCase
 
     public function test_no_response_value_by_default_means_automatically_redirecting_back_for_inertia_requests(): void
     {
-        $response = $this->http->put(uri: uri([TestController::class, 'voidPutAction']), headers: [
-            Header::INERTIA => 'true',
-            'Content-Type' => 'application/json',
-            'Referer' => '/foo',
-        ]);
+        $response = $this->http->put(
+            uri: uri([TestController::class, 'voidPutAction']),
+            headers: [
+                Header::INERTIA => 'true',
+                'Content-Type' => 'application/json',
+                'Referer' => '/foo',
+            ],
+        );
 
         $response->assertStatus(Status::SEE_OTHER);
         $this->assertSame('/foo', $response->headers['Location']->values[0]);
@@ -52,26 +55,35 @@ final class MiddlewareTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('An empty Inertia response was returned.');
 
-        $this->http->get(uri: uri([TestController::class, 'customEmptyResponseAction']), headers: [
-            Header::INERTIA => 'true',
-            'Content-Type' => 'application/json',
-        ]);
+        $this->http->get(
+            uri: uri([TestController::class, 'customEmptyResponseAction']),
+            headers: [
+                Header::INERTIA => 'true',
+                'Content-Type' => 'application/json',
+            ],
+        );
     }
 
     public function test_no_response_means_no_response_for_non_inertia_requests(): void
     {
         $this->expectException(ControllerActionHadNoReturn::class);
 
-        $this->http->put(uri: uri([TestController::class, 'voidPutAction']), headers: [
-            'Content-Type' => 'application/json',
-        ]);
+        $this->http->put(
+            uri: uri([TestController::class, 'voidPutAction']),
+            headers: [
+                'Content-Type' => 'application/json',
+            ],
+        );
     }
 
     public function test_the_version_is_optional(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'basicRender']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRender']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -84,10 +96,13 @@ final class MiddlewareTest extends TestCase
     {
         $version = 1597347897973;
 
-        $response = $this->http->get(uri: uri([TestController::class, 'numericVersion']), headers: [
-            Header::INERTIA => 'true',
-            Header::VERSION => (string) $version,
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'numericVersion']),
+            headers: [
+                Header::INERTIA => 'true',
+                Header::VERSION => (string) $version,
+            ],
+        );
 
         $page = $response->body;
 
@@ -100,10 +115,13 @@ final class MiddlewareTest extends TestCase
     {
         $version = 'foo-version';
 
-        $response = $this->http->get(uri: uri([TestController::class, 'stringVersion']), headers: [
-            Header::INERTIA => 'true',
-            Header::VERSION => $version,
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'stringVersion']),
+            headers: [
+                Header::INERTIA => 'true',
+                Header::VERSION => $version,
+            ],
+        );
 
         $page = $response->body;
 
@@ -114,10 +132,13 @@ final class MiddlewareTest extends TestCase
 
     public function test_it_will_instruct_inertia_to_reload_on_a_version_mismatch(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'stringVersion']), headers: [
-            Header::INERTIA => 'true',
-            Header::VERSION => 'a-different-version',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'stringVersion']),
+            headers: [
+                Header::INERTIA => 'true',
+                Header::VERSION => 'a-different-version',
+            ],
+        );
 
         $response->assertStatus(Status::CONFLICT);
         $this->assertSame('/string-version-test', $response->headers[Header::LOCATION]->values[0]);
@@ -126,9 +147,12 @@ final class MiddlewareTest extends TestCase
 
     public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -166,7 +190,7 @@ final class MiddlewareTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(validation: new ValidationConfig(
+            static fn () => new InertiaConfig(validation: new ValidationConfig(
                 multiple_errors: false,
                 localize_fields: false,
             )),
@@ -194,7 +218,7 @@ final class MiddlewareTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(validation: new ValidationConfig(
+            static fn () => new InertiaConfig(validation: new ValidationConfig(
                 multiple_errors: true,
                 localize_fields: false,
             )),
@@ -236,7 +260,7 @@ final class MiddlewareTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(validation: new ValidationConfig(
+            static fn () => new InertiaConfig(validation: new ValidationConfig(
                 multiple_errors: false,
                 localize_fields: true,
             )),
@@ -264,7 +288,7 @@ final class MiddlewareTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(validation: new ValidationConfig(
+            static fn () => new InertiaConfig(validation: new ValidationConfig(
                 multiple_errors: false,
                 localize_fields: false,
             )),
@@ -294,9 +318,12 @@ final class MiddlewareTest extends TestCase
         $this->assertInstanceOf(Session::class, $session);
         $session->set(Session::VALIDATION_ERRORS, ['name' => ['This should be overwritten.']]);
 
-        $response = $this->http->get(uri: uri([TestController::class, 'overwriteErrorsProp']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'overwriteErrorsProp']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -330,7 +357,7 @@ final class MiddlewareTest extends TestCase
         $directoryPath = dirname($manifestPath);
         $contents = json_encode(['vite' => true]);
 
-        if (!is_dir($directoryPath)) {
+        if (! is_dir($directoryPath)) {
             mkdir($directoryPath, 0o777, true);
         }
 
@@ -352,7 +379,7 @@ final class MiddlewareTest extends TestCase
 
     public function test_extended_middleware_only_runs_once(): void
     {
-        $this->container->singleton(Middleware::class, fn() => $this->container->get(ExampleMiddleware::class));
+        $this->container->singleton(Middleware::class, fn () => $this->container->get(ExampleMiddleware::class));
 
         $this->http->get(uri: uri([TestController::class, 'basicRender']));
 

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -36,14 +36,11 @@ final class MiddlewareTest extends TestCase
 
     public function test_no_response_value_by_default_means_automatically_redirecting_back_for_inertia_requests(): void
     {
-        $response = $this->http->put(
-            uri: uri([TestController::class, 'voidPutAction']),
-            headers: [
-                Header::INERTIA => 'true',
-                'Content-Type' => 'application/json',
-                'Referer' => '/foo',
-            ],
-        );
+        $response = $this->http->put(uri: uri([TestController::class, 'voidPutAction']), headers: [
+            Header::INERTIA => 'true',
+            'Content-Type' => 'application/json',
+            'Referer' => '/foo',
+        ]);
 
         $response->assertStatus(Status::SEE_OTHER);
         $this->assertSame('/foo', $response->headers['Location']->values[0]);
@@ -55,35 +52,26 @@ final class MiddlewareTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('An empty Inertia response was returned.');
 
-        $this->http->get(
-            uri: uri([TestController::class, 'customEmptyResponseAction']),
-            headers: [
-                Header::INERTIA => 'true',
-                'Content-Type' => 'application/json',
-            ],
-        );
+        $this->http->get(uri: uri([TestController::class, 'customEmptyResponseAction']), headers: [
+            Header::INERTIA => 'true',
+            'Content-Type' => 'application/json',
+        ]);
     }
 
     public function test_no_response_means_no_response_for_non_inertia_requests(): void
     {
         $this->expectException(ControllerActionHadNoReturn::class);
 
-        $this->http->put(
-            uri: uri([TestController::class, 'voidPutAction']),
-            headers: [
-                'Content-Type' => 'application/json',
-            ],
-        );
+        $this->http->put(uri: uri([TestController::class, 'voidPutAction']), headers: [
+            'Content-Type' => 'application/json',
+        ]);
     }
 
     public function test_the_version_is_optional(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'basicRender']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'basicRender']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -96,13 +84,10 @@ final class MiddlewareTest extends TestCase
     {
         $version = 1597347897973;
 
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'numericVersion']),
-            headers: [
-                Header::INERTIA => 'true',
-                Header::VERSION => (string) $version,
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'numericVersion']), headers: [
+            Header::INERTIA => 'true',
+            Header::VERSION => (string) $version,
+        ]);
 
         $page = $response->body;
 
@@ -115,13 +100,10 @@ final class MiddlewareTest extends TestCase
     {
         $version = 'foo-version';
 
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'stringVersion']),
-            headers: [
-                Header::INERTIA => 'true',
-                Header::VERSION => $version,
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'stringVersion']), headers: [
+            Header::INERTIA => 'true',
+            Header::VERSION => $version,
+        ]);
 
         $page = $response->body;
 
@@ -132,13 +114,10 @@ final class MiddlewareTest extends TestCase
 
     public function test_it_will_instruct_inertia_to_reload_on_a_version_mismatch(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'stringVersion']),
-            headers: [
-                Header::INERTIA => 'true',
-                Header::VERSION => 'a-different-version',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'stringVersion']), headers: [
+            Header::INERTIA => 'true',
+            Header::VERSION => 'a-different-version',
+        ]);
 
         $response->assertStatus(Status::CONFLICT);
         $this->assertSame('/string-version-test', $response->headers[Header::LOCATION]->values[0]);
@@ -147,12 +126,9 @@ final class MiddlewareTest extends TestCase
 
     public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'basicRenderWithExampleMiddleware']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -318,12 +294,9 @@ final class MiddlewareTest extends TestCase
         $this->assertInstanceOf(Session::class, $session);
         $session->set(Session::VALIDATION_ERRORS, ['name' => ['This should be overwritten.']]);
 
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'overwriteErrorsProp']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'overwriteErrorsProp']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 

--- a/tests/Integration/OptionalPropTest.php
+++ b/tests/Integration/OptionalPropTest.php
@@ -12,14 +12,14 @@ final class OptionalPropTest extends TestCase
 {
     public function test_can_invoke(): void
     {
-        $optionalProp = new OptionalProp(static fn(): string => 'A lazy value');
+        $optionalProp = new OptionalProp(static fn (): string => 'A lazy value');
 
         $this->assertSame('A lazy value', $optionalProp());
     }
 
     public function test_can_resolve_bindings_when_invoked(): void
     {
-        $optionalProp = new OptionalProp(static fn(Request $request): Request => $request);
+        $optionalProp = new OptionalProp(static fn (Request $request): Request => $request);
 
         $this->assertInstanceOf(Request::class, $optionalProp());
     }

--- a/tests/Integration/ResponseFactoryTest.php
+++ b/tests/Integration/ResponseFactoryTest.php
@@ -29,7 +29,10 @@ final class ResponseFactoryTest extends TestCase
 {
     public function test_location_response_for_inertia_requests(): void
     {
-        $this->makeRequest(uri: '/', headers: [Header::INERTIA => 'true']);
+        $this->makeRequest(
+            uri: '/',
+            headers: [Header::INERTIA => 'true'],
+        );
 
         $response = $this->factory->location('https://inertiajs.com');
 
@@ -49,7 +52,10 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_location_response_for_inertia_requests_using_redirect_response(): void
     {
-        $this->makeRequest(uri: '/', headers: [Header::INERTIA => 'true']);
+        $this->makeRequest(
+            uri: '/',
+            headers: [Header::INERTIA => 'true'],
+        );
 
         $redirect = new Redirect('https://inertiajs.com');
 
@@ -97,10 +103,13 @@ final class ResponseFactoryTest extends TestCase
     {
         $expectedVersion = 'test-version-from-closure';
 
-        $response = $this->http->get(uri: uri([TestController::class, 'versionCanBeAClosure']), headers: [
-            Header::INERTIA => 'true',
-            Header::VERSION => $expectedVersion,
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'versionCanBeAClosure']),
+            headers: [
+                Header::INERTIA => 'true',
+                Header::VERSION => $expectedVersion,
+            ],
+        );
 
         $page = $response->body;
 
@@ -115,9 +124,12 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'customUrlResolver']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'customUrlResolver']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -127,9 +139,12 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_shared_data_can_be_shared_from_anywhere(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'sharedData']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'sharedData']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -140,9 +155,12 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_dot_props_are_merged_from_shared(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'dotPropMerging']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'dotPropMerging']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
         $props = $page['props'];
@@ -154,9 +172,12 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_shared_data_can_resolve_closure_arguments(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'sharedClosure']) . '?foo=bar', headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'sharedClosure']) . '?foo=bar',
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -167,9 +188,12 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_dot_props_with_callbacks_are_merged_from_shared(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'dotPropsWithCallbacksMerging']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'dotPropsWithCallbacksMerging']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
         $props = $page['props'];
@@ -193,14 +217,14 @@ final class ResponseFactoryTest extends TestCase
         . ResponseFactory::class
         . '::lazy() is deprecated, Use `optional` instead.');
 
-        $lazyProp = $this->factory->lazy(static fn(): string => 'A lazy value');
+        $lazyProp = $this->factory->lazy(static fn (): string => 'A lazy value');
 
         $this->assertInstanceOf(LazyProp::class, $lazyProp);
     }
 
     public function test_can_create_deferred_prop(): void
     {
-        $deferredProp = $this->factory->defer(static fn(): string => 'A deferred value');
+        $deferredProp = $this->factory->defer(static fn (): string => 'A deferred value');
 
         $this->assertInstanceOf(DeferProp::class, $deferredProp);
         $this->assertSame('default', $deferredProp->group());
@@ -208,7 +232,7 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_can_create_deferred_prop_with_custom_group(): void
     {
-        $deferredProp = $this->factory->defer(static fn(): string => 'A deferred value', 'foo');
+        $deferredProp = $this->factory->defer(static fn (): string => 'A deferred value', 'foo');
 
         $this->assertInstanceOf(DeferProp::class, $deferredProp);
         $this->assertSame('foo', $deferredProp->group());
@@ -216,35 +240,35 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_can_create_merged_prop(): void
     {
-        $mergedProp = $this->factory->merge(static fn(): string => 'A merged value');
+        $mergedProp = $this->factory->merge(static fn (): string => 'A merged value');
 
         $this->assertInstanceOf(MergeProp::class, $mergedProp);
     }
 
     public function test_can_create_deep_merged_prop(): void
     {
-        $mergedProp = $this->factory->deepMerge(static fn(): string => 'A merged value');
+        $mergedProp = $this->factory->deepMerge(static fn (): string => 'A merged value');
 
         $this->assertInstanceOf(MergeProp::class, $mergedProp);
     }
 
     public function test_can_create_deferred_and_merged_prop(): void
     {
-        $deferredProp = $this->factory->defer(static fn(): string => 'A deferred + merged value')->merge();
+        $deferredProp = $this->factory->defer(static fn (): string => 'A deferred + merged value')->merge();
 
         $this->assertInstanceOf(DeferProp::class, $deferredProp);
     }
 
     public function test_can_create_deferred_and_deep_merged_prop(): void
     {
-        $deferredProp = $this->factory->defer(static fn(): string => 'A deferred + merged value')->deepMerge();
+        $deferredProp = $this->factory->defer(static fn (): string => 'A deferred + merged value')->deepMerge();
 
         $this->assertInstanceOf(DeferProp::class, $deferredProp);
     }
 
     public function test_can_create_optional_prop(): void
     {
-        $optionalProp = $this->factory->optional(static fn(): string => 'An optional value');
+        $optionalProp = $this->factory->optional(static fn (): string => 'An optional value');
 
         $this->assertInstanceOf(OptionalProp::class, $optionalProp);
     }
@@ -286,16 +310,19 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_can_create_always_prop(): void
     {
-        $alwaysProp = $this->factory->always(static fn(): string => 'An always value');
+        $alwaysProp = $this->factory->always(static fn (): string => 'An always value');
 
         $this->assertInstanceOf(AlwaysProp::class, $alwaysProp);
     }
 
     public function test_will_accept_arrayable_props(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'arrayableProps']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'arrayableProps']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -306,9 +333,12 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_will_accept_instances_of_provides_inertia_props(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'renderWithProvider']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'renderWithProvider']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
         $props = $page['props'];
@@ -321,9 +351,12 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_will_accept_arrays_containing_provides_inertia_props_in_render(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'renderWithMixedProps']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'renderWithMixedProps']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
         $props = $page['props'];
@@ -340,9 +373,12 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_can_share_instances_of_provides_inertia_props(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'shareWithProvider']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'shareWithProvider']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
         $props = $page['props'];
@@ -357,9 +393,12 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_can_share_arrays_containing_provides_inertia_props(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'shareWithMixedProps']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'shareWithMixedProps']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
         $props = $page['props'];
@@ -378,7 +417,7 @@ final class ResponseFactoryTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn() => new InertiaConfig(pages: new PageConfig(ensure_pages_exists: true)),
+            static fn () => new InertiaConfig(pages: new PageConfig(ensure_pages_exists: true)),
         );
 
         $this->expectException(ComponentNotFoundException::class);
@@ -397,7 +436,7 @@ final class ResponseFactoryTest extends TestCase
 
             $this->assertInstanceOf(Response::class, $response);
         } finally {
-            if (!$originalEnv) {
+            if (! $originalEnv) {
                 putenv('INERTIA_ENSURE_PAGES_EXISTS');
             } else {
                 putenv("INERTIA_ENSURE_PAGES_EXISTS={$originalEnv}");

--- a/tests/Integration/ResponseFactoryTest.php
+++ b/tests/Integration/ResponseFactoryTest.php
@@ -29,10 +29,7 @@ final class ResponseFactoryTest extends TestCase
 {
     public function test_location_response_for_inertia_requests(): void
     {
-        $this->makeRequest(
-            uri: '/',
-            headers: [Header::INERTIA => 'true'],
-        );
+        $this->makeRequest(uri: '/', headers: [Header::INERTIA => 'true']);
 
         $response = $this->factory->location('https://inertiajs.com');
 
@@ -52,10 +49,7 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_location_response_for_inertia_requests_using_redirect_response(): void
     {
-        $this->makeRequest(
-            uri: '/',
-            headers: [Header::INERTIA => 'true'],
-        );
+        $this->makeRequest(uri: '/', headers: [Header::INERTIA => 'true']);
 
         $redirect = new Redirect('https://inertiajs.com');
 
@@ -103,13 +97,10 @@ final class ResponseFactoryTest extends TestCase
     {
         $expectedVersion = 'test-version-from-closure';
 
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'versionCanBeAClosure']),
-            headers: [
-                Header::INERTIA => 'true',
-                Header::VERSION => $expectedVersion,
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'versionCanBeAClosure']), headers: [
+            Header::INERTIA => 'true',
+            Header::VERSION => $expectedVersion,
+        ]);
 
         $page = $response->body;
 
@@ -124,12 +115,9 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_the_url_can_be_resolved_with_a_custom_resolver(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'customUrlResolver']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'customUrlResolver']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -139,12 +127,9 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_shared_data_can_be_shared_from_anywhere(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'sharedData']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'sharedData']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -155,12 +140,9 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_dot_props_are_merged_from_shared(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'dotPropMerging']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'dotPropMerging']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
         $props = $page['props'];
@@ -172,12 +154,9 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_shared_data_can_resolve_closure_arguments(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'sharedClosure']) . '?foo=bar',
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'sharedClosure']) . '?foo=bar', headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -188,12 +167,9 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_dot_props_with_callbacks_are_merged_from_shared(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'dotPropsWithCallbacksMerging']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'dotPropsWithCallbacksMerging']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
         $props = $page['props'];
@@ -317,12 +293,9 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_will_accept_arrayable_props(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'arrayableProps']),
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'arrayableProps']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -333,10 +306,9 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_will_accept_instances_of_provides_inertia_props(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'renderWithProvider']),
-            headers: [Header::INERTIA => 'true'],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'renderWithProvider']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
         $props = $page['props'];
@@ -349,10 +321,9 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_will_accept_arrays_containing_provides_inertia_props_in_render(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'renderWithMixedProps']),
-            headers: [Header::INERTIA => 'true'],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'renderWithMixedProps']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
         $props = $page['props'];
@@ -369,10 +340,9 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_can_share_instances_of_provides_inertia_props(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'shareWithProvider']),
-            headers: [Header::INERTIA => 'true'],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'shareWithProvider']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
         $props = $page['props'];
@@ -387,10 +357,9 @@ final class ResponseFactoryTest extends TestCase
 
     public function test_can_share_arrays_containing_provides_inertia_props(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'shareWithMixedProps']),
-            headers: [Header::INERTIA => 'true'],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'shareWithMixedProps']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
         $props = $page['props'];

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -74,7 +74,7 @@ final class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = $this->factory->render('User/Edit', [
             'user' => $user,
-            'foo' => new DeferProp(static fn() => 'bar'),
+            'foo' => new DeferProp(static fn () => 'bar'),
         ]);
 
         $this->assertInstanceOf(LazyBody::class, $response->body);
@@ -112,9 +112,9 @@ final class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = $this->factory->render('User/Edit', [
             'user' => $user,
-            'foo' => new DeferProp(static fn() => 'foo value'),
-            'bar' => new DeferProp(static fn() => 'bar value'),
-            'baz' => new DeferProp(static fn() => 'baz value', 'custom'),
+            'foo' => new DeferProp(static fn () => 'foo value'),
+            'bar' => new DeferProp(static fn () => 'bar value'),
+            'baz' => new DeferProp(static fn () => 'baz value', 'custom'),
         ]);
 
         $renderer = $this->container->get(ViewRenderer::class);
@@ -169,19 +169,18 @@ final class ResponseTest extends TestCase
 
         $this->makeRequest(headers: $headers);
 
-        $scrollProp = new ScrollProp(value: ['data' => [['id' => 1]]], wrapper: 'data', metadata: new readonly class(
-            'page',
-            null,
-            2,
-            1,
-        ) implements ProvidesScrollMetadata {
-            public function __construct(
-                public string $pageName,
-                public int|null|string $previousPage,
-                public int|null|string $nextPage,
-                public int|null|string $currentPage,
-            ) {}
-        });
+        $scrollProp = new ScrollProp(
+            value: ['data' => [['id' => 1]]],
+            wrapper: 'data',
+            metadata: new readonly class('page', null, 2, 1) implements ProvidesScrollMetadata {
+                public function __construct(
+                    public string $pageName,
+                    public int|null|string $previousPage,
+                    public int|null|string $nextPage,
+                    public int|null|string $currentPage,
+                ) {}
+            },
+        );
 
         $response = $this->factory->render('User/Index', ['users' => $scrollProp]);
 
@@ -447,7 +446,7 @@ final class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = $this->factory->render('User/Edit', [
             'user' => $user,
-            'foo' => new DeferProp(static fn() => 'foo value')->merge(),
+            'foo' => new DeferProp(static fn () => 'foo value')->merge(),
             'bar' => new MergeProp('bar value'),
         ]);
 
@@ -486,7 +485,7 @@ final class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = $this->factory->render('User/Edit', [
             'user' => $user,
-            'foo' => new DeferProp(static fn() => 'foo value')->deepMerge(),
+            'foo' => new DeferProp(static fn () => 'foo value')->deepMerge(),
             'bar' => new MergeProp('bar value')->deepMerge(),
         ]);
 
@@ -645,12 +644,15 @@ final class ResponseTest extends TestCase
 
     public function test_lazy_callable_resource_response(): void
     {
-        $this->makeRequest(uri: '/users', headers: [Header::INERTIA => 'true']);
+        $this->makeRequest(
+            uri: '/users',
+            headers: [Header::INERTIA => 'true'],
+        );
         $this->factory->version('123');
 
         $response = $this->factory->render('User/Index', [
-            'users' => static fn() => [['name' => 'Jonathan']],
-            'organizations' => static fn() => [['name' => 'Inertia']],
+            'users' => static fn () => [['name' => 'Jonathan']],
+            'organizations' => static fn () => [['name' => 'Inertia']],
         ]);
 
         $page = $response->body->jsonSerialize();
@@ -665,16 +667,19 @@ final class ResponseTest extends TestCase
 
     public function test_lazy_callable_resource_partial_response(): void
     {
-        $this->makeRequest(uri: '/users', headers: [
-            Header::INERTIA => 'true',
-            Header::PARTIAL_COMPONENT => 'User/Index',
-            Header::PARTIAL_ONLY => 'users',
-        ]);
+        $this->makeRequest(
+            uri: '/users',
+            headers: [
+                Header::INERTIA => 'true',
+                Header::PARTIAL_COMPONENT => 'User/Index',
+                Header::PARTIAL_ONLY => 'users',
+            ],
+        );
         $this->factory->version('123');
 
         $response = $this->factory->render('User/Index', [
-            'users' => static fn() => [['name' => 'Jonathan']],
-            'organizations' => static fn() => [['name' => 'Inertia']],
+            'users' => static fn () => [['name' => 'Jonathan']],
+            'organizations' => static fn () => [['name' => 'Inertia']],
         ]);
 
         $page = $response->body->jsonSerialize();
@@ -691,11 +696,14 @@ final class ResponseTest extends TestCase
 
     public function test_lazy_prop_returning_pagination_is_transformed(): void
     {
-        $this->container->singleton(InertiaConfig::class, static fn() => new InertiaConfig(laravel_pagination: true));
+        $this->container->singleton(InertiaConfig::class, static fn () => new InertiaConfig(laravel_pagination: true));
 
-        $this->makeRequest(uri: '/users?page=1', headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $this->makeRequest(
+            uri: '/users?page=1',
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $callable = static function (): PaginatedData {
             $users = [
@@ -704,7 +712,11 @@ final class ResponseTest extends TestCase
                 ['name' => 'Jeffrey'],
             ];
 
-            $paginator = new Paginator(totalItems: count($users), itemsPerPage: 2, currentPage: 1);
+            $paginator = new Paginator(
+                totalItems: count($users),
+                itemsPerPage: 2,
+                currentPage: 1,
+            );
 
             return $paginator->paginate(array_slice($users, 0, 2));
         };
@@ -734,11 +746,14 @@ final class ResponseTest extends TestCase
 
     public function test_lazy_prop_returning_nested_pagination_is_transformed(): void
     {
-        $this->container->singleton(InertiaConfig::class, static fn() => new InertiaConfig(laravel_pagination: true));
+        $this->container->singleton(InertiaConfig::class, static fn () => new InertiaConfig(laravel_pagination: true));
 
-        $this->makeRequest(uri: '/users?page=1', headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $this->makeRequest(
+            uri: '/users?page=1',
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $callable = static function (): array {
             $users = [
@@ -747,7 +762,11 @@ final class ResponseTest extends TestCase
                 ['name' => 'Jeffrey'],
             ];
 
-            $paginator = new Paginator(totalItems: count($users), itemsPerPage: 2, currentPage: 1);
+            $paginator = new Paginator(
+                totalItems: count($users),
+                itemsPerPage: 2,
+                currentPage: 1,
+            );
 
             return [
                 'users' => $paginator->paginate(array_slice($users, 0, 2)),
@@ -884,7 +903,7 @@ final class ResponseTest extends TestCase
 
         $props = [
             'auth' => [
-                'user' => new LazyProp(static fn() => [
+                'user' => new LazyProp(static fn () => [
                     'name' => 'Jonathan Reinink',
                     'email' => 'jonathan@example.com',
                 ]),
@@ -918,7 +937,7 @@ final class ResponseTest extends TestCase
 
         $props = [
             'auth' => [
-                'user' => new LazyProp(static fn() => [
+                'user' => new LazyProp(static fn () => [
                     'name' => 'Jonathan Reinink',
                     'email' => 'jonathan@example.com',
                 ]),
@@ -940,11 +959,14 @@ final class ResponseTest extends TestCase
 
     public function test_lazy_props_are_not_included_by_default(): void
     {
-        $this->makeRequest(uri: '/users', headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $this->makeRequest(
+            uri: '/users',
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
-        $lazyProp = new LazyProp(static fn() => 'A lazy value');
+        $lazyProp = new LazyProp(static fn () => 'A lazy value');
 
         $response = $this->factory->render('Users', [
             'users' => [],
@@ -959,13 +981,16 @@ final class ResponseTest extends TestCase
 
     public function test_lazy_props_are_included_in_partial_reload(): void
     {
-        $this->makeRequest(uri: '/users', headers: [
-            Header::INERTIA => 'true',
-            Header::PARTIAL_COMPONENT => 'Users',
-            Header::PARTIAL_ONLY => 'lazy',
-        ]);
+        $this->makeRequest(
+            uri: '/users',
+            headers: [
+                Header::INERTIA => 'true',
+                Header::PARTIAL_COMPONENT => 'Users',
+                Header::PARTIAL_ONLY => 'lazy',
+            ],
+        );
 
-        $lazyProp = new LazyProp(static fn() => 'A lazy value');
+        $lazyProp = new LazyProp(static fn () => 'A lazy value');
 
         $response = $this->factory->render('Users', [
             'users' => [],
@@ -980,13 +1005,16 @@ final class ResponseTest extends TestCase
 
     public function test_defer_arrayable_props_are_resolved_in_partial_reload(): void
     {
-        $this->makeRequest(uri: '/users', headers: [
-            Header::INERTIA => 'true',
-            Header::PARTIAL_COMPONENT => 'Users',
-            Header::PARTIAL_ONLY => 'defer',
-        ]);
+        $this->makeRequest(
+            uri: '/users',
+            headers: [
+                Header::INERTIA => 'true',
+                Header::PARTIAL_COMPONENT => 'Users',
+                Header::PARTIAL_ONLY => 'defer',
+            ],
+        );
 
-        $deferProp = new DeferProp(static fn(): Arrayable => new class implements Arrayable {
+        $deferProp = new DeferProp(static fn (): Arrayable => new class implements Arrayable {
             #[\Override]
             public function toArray(): array
             {
@@ -1014,14 +1042,14 @@ final class ResponseTest extends TestCase
         ]);
 
         $props = [
-            'user' => new LazyProp(static fn() => [
+            'user' => new LazyProp(static fn () => [
                 'name' => 'Jonathan Reinink',
                 'email' => 'jonathan@example.com',
             ]),
             'data' => [
                 'name' => 'Taylor Otwell',
             ],
-            'errors' => new AlwaysProp(static fn() => [
+            'errors' => new AlwaysProp(static fn () => [
                 'name' => 'The email field is required.',
             ]),
         ];
@@ -1036,9 +1064,12 @@ final class ResponseTest extends TestCase
 
     public function test_inertia_responsable_objects(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'responsableProps']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'responsableProps']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
         $props = $page['props'];
@@ -1050,9 +1081,12 @@ final class ResponseTest extends TestCase
 
     public function test_props_can_be_merged_with_shared_data(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'mergeWithShared']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'mergeWithShared']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
 
@@ -1064,7 +1098,10 @@ final class ResponseTest extends TestCase
 
     public function test_top_level_dot_props_get_unpacked(): void
     {
-        $this->makeRequest(uri: '/products/123', headers: [Header::INERTIA => 'true']);
+        $this->makeRequest(
+            uri: '/products/123',
+            headers: [Header::INERTIA => 'true'],
+        );
 
         $props = [
             'auth' => [
@@ -1089,7 +1126,10 @@ final class ResponseTest extends TestCase
 
     public function test_nested_dot_props_do_not_get_unpacked(): void
     {
-        $this->makeRequest(uri: '/products/123', headers: [Header::INERTIA => 'true']);
+        $this->makeRequest(
+            uri: '/products/123',
+            headers: [Header::INERTIA => 'true'],
+        );
 
         $props = [
             'auth' => [
@@ -1114,9 +1154,12 @@ final class ResponseTest extends TestCase
 
     public function test_props_can_be_added_using_the_with_method(): void
     {
-        $response = $this->http->get(uri: uri([TestController::class, 'withMethod']), headers: [
-            Header::INERTIA => 'true',
-        ]);
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'withMethod']),
+            headers: [
+                Header::INERTIA => 'true',
+            ],
+        );
 
         $page = $response->body;
         $props = $page['props'];
@@ -1159,7 +1202,10 @@ final class ResponseTest extends TestCase
 
     public function test_the_page_url_doesnt_double_up(): void
     {
-        $this->makeRequest(uri: '/subpath/product/122', headers: [Header::INERTIA => 'true']);
+        $this->makeRequest(
+            uri: '/subpath/product/122',
+            headers: [Header::INERTIA => 'true'],
+        );
 
         $response = $this->factory->render('Product/Show', []);
         $page = $response->body;
@@ -1169,7 +1215,10 @@ final class ResponseTest extends TestCase
 
     public function test_trailing_slashes_in_a_url_are_preserved(): void
     {
-        $this->makeRequest(uri: '/users/', headers: [Header::INERTIA => 'true']);
+        $this->makeRequest(
+            uri: '/users/',
+            headers: [Header::INERTIA => 'true'],
+        );
 
         $response = $this->factory->render('User/Index', []);
         $page = $response->body;
@@ -1179,7 +1228,10 @@ final class ResponseTest extends TestCase
 
     public function test_trailing_slashes_in_a_url_with_query_parameters_are_preserved(): void
     {
-        $this->makeRequest(uri: '/users/?page=1&sort=name', headers: [Header::INERTIA => 'true']);
+        $this->makeRequest(
+            uri: '/users/?page=1&sort=name',
+            headers: [Header::INERTIA => 'true'],
+        );
 
         $response = $this->factory->render('User/Index', []);
         $page = $response->body;
@@ -1189,7 +1241,10 @@ final class ResponseTest extends TestCase
 
     public function test_a_url_without_trailing_slash_is_resolved_correctly(): void
     {
-        $this->makeRequest(uri: '/users', headers: [Header::INERTIA => 'true']);
+        $this->makeRequest(
+            uri: '/users',
+            headers: [Header::INERTIA => 'true'],
+        );
 
         $response = $this->factory->render('User/Index', []);
         $page = $response->body;
@@ -1199,7 +1254,10 @@ final class ResponseTest extends TestCase
 
     public function test_a_url_without_trailing_slash_and_query_parameters_is_resolved_correctly(): void
     {
-        $this->makeRequest(uri: '/users?page=1&sort=name', headers: [Header::INERTIA => 'true']);
+        $this->makeRequest(
+            uri: '/users?page=1&sort=name',
+            headers: [Header::INERTIA => 'true'],
+        );
 
         $response = $this->factory->render('User/Index', []);
         $page = $response->body;

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -169,18 +169,19 @@ final class ResponseTest extends TestCase
 
         $this->makeRequest(headers: $headers);
 
-        $scrollProp = new ScrollProp(
-            value: ['data' => [['id' => 1]]],
-            wrapper: 'data',
-            metadata: new readonly class('page', null, 2, 1) implements ProvidesScrollMetadata {
-                public function __construct(
-                    public string $pageName,
-                    public int|null|string $previousPage,
-                    public int|null|string $nextPage,
-                    public int|null|string $currentPage,
-                ) {}
-            },
-        );
+        $scrollProp = new ScrollProp(value: ['data' => [['id' => 1]]], wrapper: 'data', metadata: new readonly class(
+            'page',
+            null,
+            2,
+            1,
+        ) implements ProvidesScrollMetadata {
+            public function __construct(
+                public string $pageName,
+                public int|null|string $previousPage,
+                public int|null|string $nextPage,
+                public int|null|string $currentPage,
+            ) {}
+        });
 
         $response = $this->factory->render('User/Index', ['users' => $scrollProp]);
 
@@ -644,10 +645,7 @@ final class ResponseTest extends TestCase
 
     public function test_lazy_callable_resource_response(): void
     {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [Header::INERTIA => 'true'],
-        );
+        $this->makeRequest(uri: '/users', headers: [Header::INERTIA => 'true']);
         $this->factory->version('123');
 
         $response = $this->factory->render('User/Index', [
@@ -667,14 +665,11 @@ final class ResponseTest extends TestCase
 
     public function test_lazy_callable_resource_partial_response(): void
     {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [
-                Header::INERTIA => 'true',
-                Header::PARTIAL_COMPONENT => 'User/Index',
-                Header::PARTIAL_ONLY => 'users',
-            ],
-        );
+        $this->makeRequest(uri: '/users', headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Index',
+            Header::PARTIAL_ONLY => 'users',
+        ]);
         $this->factory->version('123');
 
         $response = $this->factory->render('User/Index', [
@@ -698,12 +693,9 @@ final class ResponseTest extends TestCase
     {
         $this->container->singleton(InertiaConfig::class, static fn() => new InertiaConfig(laravel_pagination: true));
 
-        $this->makeRequest(
-            uri: '/users?page=1',
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $this->makeRequest(uri: '/users?page=1', headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $callable = static function (): PaginatedData {
             $users = [
@@ -712,11 +704,7 @@ final class ResponseTest extends TestCase
                 ['name' => 'Jeffrey'],
             ];
 
-            $paginator = new Paginator(
-                totalItems: count($users),
-                itemsPerPage: 2,
-                currentPage: 1,
-            );
+            $paginator = new Paginator(totalItems: count($users), itemsPerPage: 2, currentPage: 1);
 
             return $paginator->paginate(array_slice($users, 0, 2));
         };
@@ -748,12 +736,9 @@ final class ResponseTest extends TestCase
     {
         $this->container->singleton(InertiaConfig::class, static fn() => new InertiaConfig(laravel_pagination: true));
 
-        $this->makeRequest(
-            uri: '/users?page=1',
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $this->makeRequest(uri: '/users?page=1', headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $callable = static function (): array {
             $users = [
@@ -762,11 +747,7 @@ final class ResponseTest extends TestCase
                 ['name' => 'Jeffrey'],
             ];
 
-            $paginator = new Paginator(
-                totalItems: count($users),
-                itemsPerPage: 2,
-                currentPage: 1,
-            );
+            $paginator = new Paginator(totalItems: count($users), itemsPerPage: 2, currentPage: 1);
 
             return [
                 'users' => $paginator->paginate(array_slice($users, 0, 2)),
@@ -959,12 +940,9 @@ final class ResponseTest extends TestCase
 
     public function test_lazy_props_are_not_included_by_default(): void
     {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [
-                Header::INERTIA => 'true',
-            ],
-        );
+        $this->makeRequest(uri: '/users', headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $lazyProp = new LazyProp(static fn() => 'A lazy value');
 
@@ -981,14 +959,11 @@ final class ResponseTest extends TestCase
 
     public function test_lazy_props_are_included_in_partial_reload(): void
     {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [
-                Header::INERTIA => 'true',
-                Header::PARTIAL_COMPONENT => 'Users',
-                Header::PARTIAL_ONLY => 'lazy',
-            ],
-        );
+        $this->makeRequest(uri: '/users', headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'Users',
+            Header::PARTIAL_ONLY => 'lazy',
+        ]);
 
         $lazyProp = new LazyProp(static fn() => 'A lazy value');
 
@@ -1005,14 +980,11 @@ final class ResponseTest extends TestCase
 
     public function test_defer_arrayable_props_are_resolved_in_partial_reload(): void
     {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [
-                Header::INERTIA => 'true',
-                Header::PARTIAL_COMPONENT => 'Users',
-                Header::PARTIAL_ONLY => 'defer',
-            ],
-        );
+        $this->makeRequest(uri: '/users', headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'Users',
+            Header::PARTIAL_ONLY => 'defer',
+        ]);
 
         $deferProp = new DeferProp(static fn(): Arrayable => new class implements Arrayable {
             #[\Override]
@@ -1064,10 +1036,9 @@ final class ResponseTest extends TestCase
 
     public function test_inertia_responsable_objects(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'responsableProps']),
-            headers: [Header::INERTIA => 'true'],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'responsableProps']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
         $props = $page['props'];
@@ -1079,10 +1050,9 @@ final class ResponseTest extends TestCase
 
     public function test_props_can_be_merged_with_shared_data(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'mergeWithShared']),
-            headers: [Header::INERTIA => 'true'],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'mergeWithShared']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
 
@@ -1094,10 +1064,7 @@ final class ResponseTest extends TestCase
 
     public function test_top_level_dot_props_get_unpacked(): void
     {
-        $this->makeRequest(
-            uri: '/products/123',
-            headers: [Header::INERTIA => 'true'],
-        );
+        $this->makeRequest(uri: '/products/123', headers: [Header::INERTIA => 'true']);
 
         $props = [
             'auth' => [
@@ -1122,10 +1089,7 @@ final class ResponseTest extends TestCase
 
     public function test_nested_dot_props_do_not_get_unpacked(): void
     {
-        $this->makeRequest(
-            uri: '/products/123',
-            headers: [Header::INERTIA => 'true'],
-        );
+        $this->makeRequest(uri: '/products/123', headers: [Header::INERTIA => 'true']);
 
         $props = [
             'auth' => [
@@ -1150,10 +1114,9 @@ final class ResponseTest extends TestCase
 
     public function test_props_can_be_added_using_the_with_method(): void
     {
-        $response = $this->http->get(
-            uri: uri([TestController::class, 'withMethod']),
-            headers: [Header::INERTIA => 'true'],
-        );
+        $response = $this->http->get(uri: uri([TestController::class, 'withMethod']), headers: [
+            Header::INERTIA => 'true',
+        ]);
 
         $page = $response->body;
         $props = $page['props'];
@@ -1196,10 +1159,7 @@ final class ResponseTest extends TestCase
 
     public function test_the_page_url_doesnt_double_up(): void
     {
-        $this->makeRequest(
-            uri: '/subpath/product/122',
-            headers: [Header::INERTIA => 'true'],
-        );
+        $this->makeRequest(uri: '/subpath/product/122', headers: [Header::INERTIA => 'true']);
 
         $response = $this->factory->render('Product/Show', []);
         $page = $response->body;
@@ -1209,10 +1169,7 @@ final class ResponseTest extends TestCase
 
     public function test_trailing_slashes_in_a_url_are_preserved(): void
     {
-        $this->makeRequest(
-            uri: '/users/',
-            headers: [Header::INERTIA => 'true'],
-        );
+        $this->makeRequest(uri: '/users/', headers: [Header::INERTIA => 'true']);
 
         $response = $this->factory->render('User/Index', []);
         $page = $response->body;
@@ -1222,10 +1179,7 @@ final class ResponseTest extends TestCase
 
     public function test_trailing_slashes_in_a_url_with_query_parameters_are_preserved(): void
     {
-        $this->makeRequest(
-            uri: '/users/?page=1&sort=name',
-            headers: [Header::INERTIA => 'true'],
-        );
+        $this->makeRequest(uri: '/users/?page=1&sort=name', headers: [Header::INERTIA => 'true']);
 
         $response = $this->factory->render('User/Index', []);
         $page = $response->body;
@@ -1235,10 +1189,7 @@ final class ResponseTest extends TestCase
 
     public function test_a_url_without_trailing_slash_is_resolved_correctly(): void
     {
-        $this->makeRequest(
-            uri: '/users',
-            headers: [Header::INERTIA => 'true'],
-        );
+        $this->makeRequest(uri: '/users', headers: [Header::INERTIA => 'true']);
 
         $response = $this->factory->render('User/Index', []);
         $page = $response->body;
@@ -1248,10 +1199,7 @@ final class ResponseTest extends TestCase
 
     public function test_a_url_without_trailing_slash_and_query_parameters_is_resolved_correctly(): void
     {
-        $this->makeRequest(
-            uri: '/users?page=1&sort=name',
-            headers: [Header::INERTIA => 'true'],
-        );
+        $this->makeRequest(uri: '/users?page=1&sort=name', headers: [Header::INERTIA => 'true']);
 
         $response = $this->factory->render('User/Index', []);
         $page = $response->body;

--- a/tests/Integration/ScrollMetadataTest.php
+++ b/tests/Integration/ScrollMetadataTest.php
@@ -93,15 +93,15 @@ final class ScrollMetadataTest extends TestCase
 
     public function test_extract_metadata_when_laravel_adapter_is_used(): void
     {
-        $this->container->singleton(InertiaConfig::class, static fn() => new InertiaConfig(laravel_pagination: true));
+        $this->container->singleton(InertiaConfig::class, static fn () => new InertiaConfig(laravel_pagination: true));
 
         $mockRequest = $this->makeRequest(uri: '/users');
 
-        $tempestPaginator1 = new Paginator(totalItems: 40, itemsPerPage: 15, currentPage: 1)->paginate(array_slice(
-            $this->users,
-            0,
-            15,
-        ));
+        $tempestPaginator1 = new Paginator(
+            totalItems: 40,
+            itemsPerPage: 15,
+            currentPage: 1,
+        )->paginate(array_slice($this->users, 0, 15));
 
         $laravelPaginator1 = new PaginatorAdapter($tempestPaginator1, $mockRequest)->toIlluminatePaginator();
 
@@ -115,11 +115,11 @@ final class ScrollMetadataTest extends TestCase
             ScrollMetadata::fromPaginator($laravelPaginator1)->toArray(),
         );
 
-        $tempestPaginator2 = new Paginator(totalItems: 40, itemsPerPage: 15, currentPage: 2)->paginate(array_slice(
-            $this->users,
-            15,
-            15,
-        ));
+        $tempestPaginator2 = new Paginator(
+            totalItems: 40,
+            itemsPerPage: 15,
+            currentPage: 2,
+        )->paginate(array_slice($this->users, 15, 15));
 
         $laravelPaginator2 = new PaginatorAdapter($tempestPaginator2, $mockRequest)->toIlluminatePaginator();
 
@@ -133,11 +133,11 @@ final class ScrollMetadataTest extends TestCase
             ScrollMetadata::fromPaginator($laravelPaginator2)->toArray(),
         );
 
-        $tempestPaginator3 = new Paginator(totalItems: 40, itemsPerPage: 15, currentPage: 3)->paginate(array_slice(
-            $this->users,
-            30,
-            10,
-        ));
+        $tempestPaginator3 = new Paginator(
+            totalItems: 40,
+            itemsPerPage: 15,
+            currentPage: 3,
+        )->paginate(array_slice($this->users, 30, 10));
 
         $laravelPaginator3 = new PaginatorAdapter($tempestPaginator3, $mockRequest)->toIlluminatePaginator();
 

--- a/tests/Integration/ScrollMetadataTest.php
+++ b/tests/Integration/ScrollMetadataTest.php
@@ -97,11 +97,11 @@ final class ScrollMetadataTest extends TestCase
 
         $mockRequest = $this->makeRequest(uri: '/users');
 
-        $tempestPaginator1 = new Paginator(
-            totalItems: 40,
-            itemsPerPage: 15,
-            currentPage: 1,
-        )->paginate(array_slice($this->users, 0, 15));
+        $tempestPaginator1 = new Paginator(totalItems: 40, itemsPerPage: 15, currentPage: 1)->paginate(array_slice(
+            $this->users,
+            0,
+            15,
+        ));
 
         $laravelPaginator1 = new PaginatorAdapter($tempestPaginator1, $mockRequest)->toIlluminatePaginator();
 
@@ -115,11 +115,11 @@ final class ScrollMetadataTest extends TestCase
             ScrollMetadata::fromPaginator($laravelPaginator1)->toArray(),
         );
 
-        $tempestPaginator2 = new Paginator(
-            totalItems: 40,
-            itemsPerPage: 15,
-            currentPage: 2,
-        )->paginate(array_slice($this->users, 15, 15));
+        $tempestPaginator2 = new Paginator(totalItems: 40, itemsPerPage: 15, currentPage: 2)->paginate(array_slice(
+            $this->users,
+            15,
+            15,
+        ));
 
         $laravelPaginator2 = new PaginatorAdapter($tempestPaginator2, $mockRequest)->toIlluminatePaginator();
 
@@ -133,11 +133,11 @@ final class ScrollMetadataTest extends TestCase
             ScrollMetadata::fromPaginator($laravelPaginator2)->toArray(),
         );
 
-        $tempestPaginator3 = new Paginator(
-            totalItems: 40,
-            itemsPerPage: 15,
-            currentPage: 3,
-        )->paginate(array_slice($this->users, 30, 10));
+        $tempestPaginator3 = new Paginator(totalItems: 40, itemsPerPage: 15, currentPage: 3)->paginate(array_slice(
+            $this->users,
+            30,
+            10,
+        ));
 
         $laravelPaginator3 = new PaginatorAdapter($tempestPaginator3, $mockRequest)->toIlluminatePaginator();
 

--- a/tests/Integration/ScrollPropTest.php
+++ b/tests/Integration/ScrollPropTest.php
@@ -56,7 +56,7 @@ final class ScrollPropTest extends TestCase
 
     public function test_resolves_custom_meta_data(): void
     {
-        $callableMetadata = static fn() => new readonly class('usersPage', 10, 12, 11) implements
+        $callableMetadata = static fn () => new readonly class('usersPage', 10, 12, 11) implements
             ProvidesScrollMetadata {
             public function __construct(
                 public string $pageName,
@@ -66,7 +66,11 @@ final class ScrollPropTest extends TestCase
             ) {}
         };
 
-        $scrollProp = new ScrollProp(value: $this->users, wrapper: 'data', metadata: $callableMetadata);
+        $scrollProp = new ScrollProp(
+            value: $this->users,
+            wrapper: 'data',
+            metadata: $callableMetadata,
+        );
 
         $metadata = $scrollProp->metadata();
 
@@ -111,7 +115,10 @@ final class ScrollPropTest extends TestCase
         $this->makeRequest(headers: [
             Header::INFINITE_SCROLL_MERGE_INTENT => 'prepend',
         ]);
-        $prependProp = new ScrollProp(value: $this->users, wrapper: 'items');
+        $prependProp = new ScrollProp(
+            value: $this->users,
+            wrapper: 'items',
+        );
         $prependProp->configureMergeIntent();
 
         $this->assertSame(['items'], $prependProp->prependsAtPaths());
@@ -120,7 +127,7 @@ final class ScrollPropTest extends TestCase
 
     public function test_resolves_meta_data_with_callable_provider(): void
     {
-        $callableMetadata = static fn() => new readonly class('callablePage', 5, 7, 6) implements
+        $callableMetadata = static fn () => new readonly class('callablePage', 5, 7, 6) implements
             ProvidesScrollMetadata {
             public function __construct(
                 public string $pageName,
@@ -130,7 +137,11 @@ final class ScrollPropTest extends TestCase
             ) {}
         };
 
-        $scrollProp = new ScrollProp(value: [], wrapper: 'data', metadata: $callableMetadata);
+        $scrollProp = new ScrollProp(
+            value: [],
+            wrapper: 'data',
+            metadata: $callableMetadata,
+        );
 
         $metadata = $scrollProp->metadata();
 

--- a/tests/Integration/ScrollPropTest.php
+++ b/tests/Integration/ScrollPropTest.php
@@ -66,11 +66,7 @@ final class ScrollPropTest extends TestCase
             ) {}
         };
 
-        $scrollProp = new ScrollProp(
-            value: $this->users,
-            wrapper: 'data',
-            metadata: $callableMetadata,
-        );
+        $scrollProp = new ScrollProp(value: $this->users, wrapper: 'data', metadata: $callableMetadata);
 
         $metadata = $scrollProp->metadata();
 
@@ -115,10 +111,7 @@ final class ScrollPropTest extends TestCase
         $this->makeRequest(headers: [
             Header::INFINITE_SCROLL_MERGE_INTENT => 'prepend',
         ]);
-        $prependProp = new ScrollProp(
-            value: $this->users,
-            wrapper: 'items',
-        );
+        $prependProp = new ScrollProp(value: $this->users, wrapper: 'items');
         $prependProp->configureMergeIntent();
 
         $this->assertSame(['items'], $prependProp->prependsAtPaths());
@@ -137,11 +130,7 @@ final class ScrollPropTest extends TestCase
             ) {}
         };
 
-        $scrollProp = new ScrollProp(
-            value: [],
-            wrapper: 'data',
-            metadata: $callableMetadata,
-        );
+        $scrollProp = new ScrollProp(value: [], wrapper: 'data', metadata: $callableMetadata);
 
         $metadata = $scrollProp->metadata();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -70,11 +70,7 @@ abstract class TestCase extends IntegrationTest
         Method $method = Method::GET,
         array $headers = [],
     ): Request {
-        $request = new GenericRequest(
-            method: $method,
-            uri: $uri,
-            headers: $headers,
-        );
+        $request = new GenericRequest(method: $method, uri: $uri, headers: $headers);
         $this->container->singleton(Request::class, static fn() => $request);
 
         return $request;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,7 +57,7 @@ abstract class TestCase extends IntegrationTest
     {
         $application = new HttpApplication($this->container);
 
-        $this->container->singleton(Application::class, static fn() => $application);
+        $this->container->singleton(Application::class, static fn () => $application);
 
         return $application;
     }
@@ -70,8 +70,12 @@ abstract class TestCase extends IntegrationTest
         Method $method = Method::GET,
         array $headers = [],
     ): Request {
-        $request = new GenericRequest(method: $method, uri: $uri, headers: $headers);
-        $this->container->singleton(Request::class, static fn() => $request);
+        $request = new GenericRequest(
+            method: $method,
+            uri: $uri,
+            headers: $headers,
+        );
+        $this->container->singleton(Request::class, static fn () => $request);
 
         return $request;
     }


### PR DESCRIPTION
This PR is currently on hold. While the dependency bumps are fine, some of the automated formatting changes introduced by the updated Mago ruleset reduce readability rather than improve it. I don’t want to merge these changes until I decide whether to adjust the linter configuration or wait for a future release that improves the defaults.