### PR TITLE
fix: exclude strings from callable resolution logic

### DIFF
--- a/src/Props/AlwaysProp.php
+++ b/src/Props/AlwaysProp.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Inertia\Props;
 
-use Closure;
 use Inertia\Contracts\InvokableProp;
+use Inertia\Traits\ResolvesCallables;
 use Override;
-
-use function Tempest\invoke;
 
 final readonly class AlwaysProp implements InvokableProp
 {
+    use ResolvesCallables;
+
     /**
      * Create a new always property instance. Always properties are included
      * in every Inertia response, even during partial reloads when only
@@ -27,14 +27,6 @@ final readonly class AlwaysProp implements InvokableProp
     #[Override]
     public function __invoke(): mixed
     {
-        if (! is_callable($this->value)) {
-            return $this->value;
-        }
-
-        if ($this->value instanceof Closure) {
-            return invoke($this->value);
-        }
-
-        return call_user_func($this->value);
+        return $this->resolveCallable($this->value);
     }
 }

--- a/src/Props/DeferProp.php
+++ b/src/Props/DeferProp.php
@@ -8,13 +8,13 @@ use Inertia\Contracts\IgnoreFirstLoad;
 use Inertia\Contracts\InvokableProp;
 use Inertia\Contracts\Mergeable;
 use Inertia\Traits\MergesProps;
+use Inertia\Traits\ResolvesCallables;
 use Override;
-
-use function Tempest\invoke;
 
 final class DeferProp implements IgnoreFirstLoad, Mergeable, InvokableProp
 {
     use MergesProps;
+    use ResolvesCallables;
 
     /**
      * @var callable
@@ -49,6 +49,6 @@ final class DeferProp implements IgnoreFirstLoad, Mergeable, InvokableProp
     #[Override]
     public function __invoke(): mixed
     {
-        return invoke($this->callback);
+        return $this->resolveCallable($this->callback);
     }
 }

--- a/src/Props/LazyProp.php
+++ b/src/Props/LazyProp.php
@@ -6,15 +6,16 @@ namespace Inertia\Props;
 
 use Inertia\Contracts\IgnoreFirstLoad;
 use Inertia\Contracts\InvokableProp;
+use Inertia\Traits\ResolvesCallables;
 use Override;
-
-use function Tempest\invoke;
 
 /**
  * @deprecated Use OptionalProp instead for clearer semantics.
  */
 final class LazyProp implements IgnoreFirstLoad, InvokableProp
 {
+    use ResolvesCallables;
+
     /**
      * @var callable
      */
@@ -31,6 +32,6 @@ final class LazyProp implements IgnoreFirstLoad, InvokableProp
     #[Override]
     public function __invoke(): mixed
     {
-        return invoke($this->callback);
+        return $this->resolveCallable($this->callback);
     }
 }

--- a/src/Props/MergeProp.php
+++ b/src/Props/MergeProp.php
@@ -7,13 +7,13 @@ namespace Inertia\Props;
 use Inertia\Contracts\InvokableProp;
 use Inertia\Contracts\Mergeable;
 use Inertia\Traits\MergesProps;
+use Inertia\Traits\ResolvesCallables;
 use Override;
-
-use function Tempest\invoke;
 
 class MergeProp implements Mergeable, InvokableProp
 {
     use MergesProps;
+    use ResolvesCallables;
 
     /**
      * Create a new merge property instance. Merge properties are combined
@@ -32,6 +32,6 @@ class MergeProp implements Mergeable, InvokableProp
     #[Override]
     public function __invoke(): mixed
     {
-        return is_callable($this->value) ? invoke($this->value) : $this->value;
+        return $this->resolveCallable($this->value);
     }
 }

--- a/src/Props/OptionalProp.php
+++ b/src/Props/OptionalProp.php
@@ -6,12 +6,13 @@ namespace Inertia\Props;
 
 use Inertia\Contracts\IgnoreFirstLoad;
 use Inertia\Contracts\InvokableProp;
+use Inertia\Traits\ResolvesCallables;
 use Override;
-
-use function Tempest\invoke;
 
 class OptionalProp implements IgnoreFirstLoad, InvokableProp
 {
+    use ResolvesCallables;
+
     /**
      * @var callable
      */
@@ -33,6 +34,6 @@ class OptionalProp implements IgnoreFirstLoad, InvokableProp
     #[Override]
     public function __invoke(): mixed
     {
-        return invoke($this->callback);
+        return $this->resolveCallable($this->callback);
     }
 }

--- a/src/Props/ScrollProp.php
+++ b/src/Props/ScrollProp.php
@@ -10,11 +10,11 @@ use Inertia\Contracts\ProvidesScrollMetadata;
 use Inertia\Support\Header;
 use Inertia\Support\ScrollMetadata;
 use Inertia\Traits\MergesProps;
+use Inertia\Traits\ResolvesCallables;
 use Override;
 use Tempest\Http\Request;
 
 use function Tempest\get;
-use function Tempest\invoke;
 
 /**
  * Represents a paginated property that can be merged during partial reloads.
@@ -25,6 +25,7 @@ use function Tempest\invoke;
 final class ScrollProp implements Mergeable, InvokableProp
 {
     use MergesProps;
+    use ResolvesCallables;
 
     /**
      * The resolved property value.
@@ -97,7 +98,7 @@ final class ScrollProp implements Mergeable, InvokableProp
     #[Override]
     public function __invoke(): mixed
     {
-        return $this->resolved ?? ($this->resolved = is_callable($this->value) ? invoke($this->value) : $this->value);
+        return $this->resolved ?? ($this->resolved = $this->resolveCallable($this->value));
     }
 
     /**

--- a/src/Traits/ResolvesCallables.php
+++ b/src/Traits/ResolvesCallables.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Traits;
+
+use Closure;
+
+use function Tempest\invoke;
+
+trait ResolvesCallables
+{
+    /**
+     * Resolve a value that may be callable.
+     */
+    protected function resolveCallable(mixed $value): mixed
+    {
+        if (! is_callable($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if ($value instanceof Closure) {
+            return invoke($value);
+        }
+
+        return $value();
+    }
+}

--- a/src/Traits/ResolvesCallables.php
+++ b/src/Traits/ResolvesCallables.php
@@ -15,11 +15,7 @@ trait ResolvesCallables
      */
     protected function resolveCallable(mixed $value): mixed
     {
-        if (! is_callable($value)) {
-            return $value;
-        }
-
-        if (is_string($value)) {
+        if (! is_callable($value) || is_string($value)) {
             return $value;
         }
 
@@ -27,6 +23,6 @@ trait ResolvesCallables
             return invoke($value);
         }
 
-        return $value();
+        return call_user_func($value);
     }
 }

--- a/tests/Integration/AlwaysPropTest.php
+++ b/tests/Integration/AlwaysPropTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Inertia\Tests\Integration;
+
 use Inertia\Props\AlwaysProp;
 use Inertia\Tests\TestCase;
 use Tempest\Http\Request;
@@ -20,6 +22,13 @@ final class AlwaysPropTest extends TestCase
         $alwaysProp = new AlwaysProp('An always value');
 
         $this->assertSame('An always value', $alwaysProp());
+    }
+
+    public function test_string_function_names_are_not_invoked(): void
+    {
+        $alwaysProp = new AlwaysProp('date');
+
+        $this->assertSame('date', $alwaysProp());
     }
 
     public function test_can_accept_callables(): void

--- a/tests/Integration/DeferPropTest.php
+++ b/tests/Integration/DeferPropTest.php
@@ -18,6 +18,13 @@ final class DeferPropTest extends TestCase
         $this->assertSame('default', $deferProp->group());
     }
 
+    public function test_string_function_names_are_not_invoked(): void
+    {
+        $deferProp = new DeferProp('date');
+
+        $this->assertSame('date', $deferProp());
+    }
+
     public function test_can_invoke_and_merge(): void
     {
         $deferProp = new DeferProp(static fn (): string => 'A deferred value')->merge();

--- a/tests/Integration/LazyPropTest.php
+++ b/tests/Integration/LazyPropTest.php
@@ -17,6 +17,13 @@ final class LazyPropTest extends TestCase
         $this->assertSame('A lazy value', $lazyProp());
     }
 
+    public function test_string_function_names_are_not_invoked(): void
+    {
+        $lazyProp = new LazyProp('date');
+
+        $this->assertSame('date', $lazyProp());
+    }
+
     public function test_can_resolve_bindings_when_invoked(): void
     {
         $lazyProp = new LazyProp(static fn (Request $request): Request => $request);

--- a/tests/Integration/MergePropTest.php
+++ b/tests/Integration/MergePropTest.php
@@ -24,6 +24,13 @@ final class MergePropTest extends TestCase
         $this->assertSame(['key' => 'value'], $mergeProp());
     }
 
+    public function test_string_function_names_are_not_invoked(): void
+    {
+        $mergeProp = new MergeProp('date');
+
+        $this->assertSame('date', $mergeProp());
+    }
+
     public function test_can_resolve_bindings_when_invoked(): void
     {
         $mergeProp = new MergeProp(static fn (Request $request): Request => $request);

--- a/tests/Integration/OptionalPropTest.php
+++ b/tests/Integration/OptionalPropTest.php
@@ -17,6 +17,13 @@ final class OptionalPropTest extends TestCase
         $this->assertSame('A lazy value', $optionalProp());
     }
 
+    public function test_string_function_names_are_not_invoked(): void
+    {
+        $optionalProp = new OptionalProp('date');
+
+        $this->assertSame('date', $optionalProp());
+    }
+
     public function test_can_resolve_bindings_when_invoked(): void
     {
         $optionalProp = new OptionalProp(static fn (Request $request): Request => $request);

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -1062,6 +1062,21 @@ final class ResponseTest extends TestCase
         $this->assertArrayNotHasKey('user', $page['props']);
     }
 
+    public function test_string_function_names_are_not_invoked_as_callables(): void
+    {
+        $this->makeRequest();
+
+        $response = $this->factory->render('User/Edit', [
+            'always' => new AlwaysProp('date'),
+            'merge' => new MergeProp('trim'),
+        ]);
+
+        $page = $response->body->inertia['page'];
+
+        $this->assertSame('date', $page['props']['always']);
+        $this->assertSame('trim', $page['props']['merge']);
+    }
+
     public function test_inertia_responsable_objects(): void
     {
         $response = $this->http->get(

--- a/tests/Integration/ScrollPropTest.php
+++ b/tests/Integration/ScrollPropTest.php
@@ -177,4 +177,11 @@ final class ScrollPropTest extends TestCase
         $this->assertSame($value1, $value2);
         $this->assertSame($value2, $value3);
     }
+
+    public function test_string_function_names_are_not_invoked(): void
+    {
+        $scrollProp = new ScrollProp('date');
+
+        $this->assertSame('date', $scrollProp());
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * String function names (e.g., "date", "trim") are no longer treated as callables by property resolvers; they are preserved and returned as plain strings.

* **Tests**
  * Added integration tests to verify string function names are not invoked across property types and in response rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->