### PR TITLE
fix: prop modifiers being ignored in provider classes

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -10,6 +10,7 @@ use Rector\Config\RectorConfig;
 use Rector\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector;
+use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
@@ -45,4 +46,5 @@ return RectorConfig::configure()
         StaticCallOnNonStaticToInstanceCallRector::class,
         NullableCompareToNullRector::class,
         ExplicitBoolCompareRector::class,
+        ArrayToFirstClassCallableRector::class,
     ]);

--- a/src/Response.php
+++ b/src/Response.php
@@ -87,6 +87,8 @@ final class Response implements HttpResponse
     ) {
         $this->body = new LazyBody(function (): array|null|InertiaView {
             $this->props = $this->normalizeProps($this->props);
+            $this->props = $this->resolveInertiaPropsProviders($this->props);
+
             $resolvedProps = $this->resolveProperties($this->props);
 
             $page = array_merge(
@@ -181,7 +183,6 @@ final class Response implements HttpResponse
      */
     public function resolveProperties(array $props): array
     {
-        $props = $this->resolveInertiaPropsProviders($props);
         $props = $this->resolvePartialProperties($props);
         $props = $this->resolveAlways($props);
 

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -7,13 +7,16 @@ namespace Inertia\Tests\Integration;
 use GuzzleHttp\Promise\PromiseInterface;
 use Inertia\Configs\InertiaConfig;
 use Inertia\Contracts\Arrayable;
+use Inertia\Contracts\ProvidesInertiaProperties;
 use Inertia\Contracts\ProvidesScrollMetadata;
 use Inertia\Props\AlwaysProp;
 use Inertia\Props\DeferProp;
 use Inertia\Props\LazyProp;
 use Inertia\Props\MergeProp;
 use Inertia\Props\ScrollProp;
+use Inertia\Response;
 use Inertia\Support\Header;
+use Inertia\Support\RenderContext;
 use Inertia\Tests\Fixtures\FakeResource;
 use Inertia\Tests\Fixtures\TestController;
 use Inertia\Tests\TestCase;
@@ -1256,5 +1259,78 @@ final class ResponseTest extends TestCase
         $page = $response->body;
 
         $this->assertSame('/users?page=1&sort=name', $page['url']);
+    }
+
+    #[Test]
+    public function deferred_props_from_provides_inertia_properties_are_included_in_deferred_props_metadata(): void
+    {
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'user' => ['name' => 'Jonathan'],
+                new class implements ProvidesInertiaProperties {
+                    public function toInertiaProperties(RenderContext $context): iterable
+                    {
+                        return [
+                            'foo' => new DeferProp(static fn () => 'bar', 'default'),
+                        ];
+                    }
+                },
+            ],
+        );
+
+        $page = $response->body->inertia['page'];
+
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertSame(['default' => ['foo']], $page['deferredProps']);
+    }
+
+    #[Test]
+    public function merge_props_from_provides_inertia_properties_are_included_in_merge_props_metadata(): void
+    {
+        $response = new Response('User/Edit', [
+            'user' => ['name' => 'Jonathan'],
+            new class implements ProvidesInertiaProperties {
+                public function toInertiaProperties(RenderContext $context): iterable
+                {
+                    return [
+                        'foo' => new MergeProp('foo value'),
+                    ];
+                }
+            },
+        ]);
+
+        $page = $response->body->inertia['page'];
+
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('foo value', $page['props']['foo']);
+        $this->assertSame(['foo'], $page['mergeProps']);
+    }
+
+    #[Test]
+    public function deferred_merge_props_from_provides_inertia_properties_include_both_metadata(): void
+    {
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'user' => ['name' => 'Jonathan'],
+                new class implements ProvidesInertiaProperties {
+                    public function toInertiaProperties(RenderContext $context): iterable
+                    {
+                        return [
+                            'foo' => new DeferProp(static fn () => 'foo value', 'default')->merge(),
+                        ];
+                    }
+                },
+            ],
+        );
+
+        $page = $response->body->inertia['page'];
+
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertSame(['default' => ['foo']], $page['deferredProps']);
+        $this->assertSame(['foo'], $page['mergeProps']);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed response property resolution to prevent duplicate processing.

* **Tests**
  * Added test coverage for deferred and merged properties in responses.

* **Chores**
  * Updated development tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->