### PR TITLE
feat: support `once()` props

### DIFF
--- a/src/Contracts/Onceable.php
+++ b/src/Contracts/Onceable.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Contracts;
+
+use BackedEnum;
+use Tempest\DateTime\Duration;
+use UnitEnum;
+
+interface Onceable
+{
+    /**
+     * Mark the prop to be resolved only once.
+     */
+    public function once(bool $value = true): static;
+
+    /**
+     * Determine if the prop should be resolved only once.
+     */
+    public function shouldResolveOnce(): bool;
+
+    /**
+     * Determine if the prop was marked as fresh.
+     */
+    public function shouldBeRefreshed(): bool;
+
+    /**
+     * Get the custom key for resolving the once prop.
+     */
+    public function getKey(): ?string;
+
+    /**
+     * Set a custom key for resolving the once prop.
+     */
+    public function as(BackedEnum|UnitEnum|string $key): static;
+
+    /**
+     * Set the expiration for the once prop.
+     */
+    public function until(Duration|int $delay): static;
+
+    /**
+     * Get the expiration timestamp in milliseconds for the once prop.
+     */
+    public function expiresAt(): ?int;
+}

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -13,6 +13,7 @@ use Inertia\Props\AlwaysProp;
 use Inertia\Props\DeferProp;
 use Inertia\Props\LazyProp;
 use Inertia\Props\MergeProp;
+use Inertia\Props\OnceProp;
 use Inertia\Props\OptionalProp;
 use Inertia\Props\ScrollProp;
 use Inertia\Support\Facade;
@@ -123,6 +124,11 @@ class Inertia extends Facade
                 callback: $callback,
                 group: $group,
             );
+    }
+
+    public static function once(callable $callback): OnceProp
+    {
+        return static::instance()->once($callback);
     }
 
     public static function always(mixed $value): AlwaysProp

--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -6,6 +6,7 @@ namespace Inertia\Middleware;
 
 use Closure;
 use Inertia\LazyBody;
+use Inertia\Props\OnceProp;
 use Inertia\Response as InertiaResponse;
 use Inertia\ResponseFactory;
 use Inertia\Support\Header;
@@ -85,6 +86,16 @@ class Middleware implements HttpMiddleware
     }
 
     /**
+     * Define the props that are shared once and remembered across navigations.
+     *
+     * @return array<string, callable|OnceProp>
+     */
+    public function shareOnce(): array
+    {
+        return [];
+    }
+
+    /**
      * Sets the root template loaded on the first page visit.
      *
      * @see https://inertiajs.com/server-side-setup#root-template
@@ -113,6 +124,15 @@ class Middleware implements HttpMiddleware
     {
         $this->inertia->version($this->version(...));
         $this->inertia->share($this->share($request));
+
+        foreach ($this->shareOnce() as $key => $value) {
+            if ($value instanceof OnceProp) {
+                $this->inertia->share($key, $value);
+            } else {
+                $this->inertia->shareOnce($key, $value);
+            }
+        }
+
         $this->inertia->setRootView($this->rootView());
 
         $urlResolver = $this->urlResolver();

--- a/src/Props/DeferProp.php
+++ b/src/Props/DeferProp.php
@@ -7,14 +7,17 @@ namespace Inertia\Props;
 use Inertia\Contracts\IgnoreFirstLoad;
 use Inertia\Contracts\InvokableProp;
 use Inertia\Contracts\Mergeable;
+use Inertia\Contracts\Onceable;
 use Inertia\Traits\MergesProps;
 use Inertia\Traits\ResolvesCallables;
+use Inertia\Traits\ResolvesOnce;
 use Override;
 
-final class DeferProp implements IgnoreFirstLoad, Mergeable, InvokableProp
+final class DeferProp implements IgnoreFirstLoad, Mergeable, Onceable, InvokableProp
 {
     use MergesProps;
     use ResolvesCallables;
+    use ResolvesOnce;
 
     /**
      * @var callable

--- a/src/Props/MergeProp.php
+++ b/src/Props/MergeProp.php
@@ -6,14 +6,17 @@ namespace Inertia\Props;
 
 use Inertia\Contracts\InvokableProp;
 use Inertia\Contracts\Mergeable;
+use Inertia\Contracts\Onceable;
 use Inertia\Traits\MergesProps;
 use Inertia\Traits\ResolvesCallables;
+use Inertia\Traits\ResolvesOnce;
 use Override;
 
-class MergeProp implements Mergeable, InvokableProp
+class MergeProp implements Mergeable, Onceable, InvokableProp
 {
     use MergesProps;
     use ResolvesCallables;
+    use ResolvesOnce;
 
     /**
      * Create a new merge property instance. Merge properties are combined

--- a/src/Props/OnceProp.php
+++ b/src/Props/OnceProp.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Inertia\Props;
 
-use Inertia\Contracts\IgnoreFirstLoad;
 use Inertia\Contracts\InvokableProp;
+use Inertia\Contracts\Onceable;
 use Inertia\Traits\ResolvesCallables;
 use Inertia\Traits\ResolvesOnce;
 use Override;
 
-class OptionalProp implements IgnoreFirstLoad, InvokableProp
+class OnceProp implements Onceable, InvokableProp
 {
     use ResolvesCallables;
     use ResolvesOnce;
@@ -21,13 +21,12 @@ class OptionalProp implements IgnoreFirstLoad, InvokableProp
     private $callback;
 
     /**
-     * Create a new optional property instance. Optional properties are only
-     * included when explicitly requested via partial reloads, reducing
-     * initial payload size and improving performance.
+     * Create a new once property instance.
      */
     public function __construct(callable $callback)
     {
         $this->callback = $callback;
+        $this->once = true;
     }
 
     /**

--- a/src/Props/OptionalProp.php
+++ b/src/Props/OptionalProp.php
@@ -6,11 +6,12 @@ namespace Inertia\Props;
 
 use Inertia\Contracts\IgnoreFirstLoad;
 use Inertia\Contracts\InvokableProp;
+use Inertia\Contracts\Onceable;
 use Inertia\Traits\ResolvesCallables;
 use Inertia\Traits\ResolvesOnce;
 use Override;
 
-class OptionalProp implements IgnoreFirstLoad, InvokableProp
+class OptionalProp implements IgnoreFirstLoad, Onceable, InvokableProp
 {
     use ResolvesCallables;
     use ResolvesOnce;

--- a/src/Response.php
+++ b/src/Response.php
@@ -408,11 +408,7 @@ final class Response implements HttpResponse
      */
     public function getMergePropsForRequest(bool $rejectResetProps = true): array
     {
-        $props = array_filter(
-            $this->props,
-            static fn ($prop) => $prop instanceof Mergeable && $prop->shouldMerge(),
-            ARRAY_FILTER_USE_BOTH,
-        );
+        $props = array_filter($this->props, static fn ($prop) => $prop instanceof Mergeable && $prop->shouldMerge());
 
         if ($rejectResetProps) {
             $resetProps = $this->parseHeaderAsArray(Header::RESET);
@@ -560,7 +556,6 @@ final class Response implements HttpResponse
         $props = array_filter(
             $this->props,
             static fn ($prop) => $prop instanceof Onceable && $prop->shouldResolveOnce(),
-            ARRAY_FILTER_USE_BOTH,
         );
 
         $only = $this->parseHeaderAsArray(Header::PARTIAL_ONLY);

--- a/src/Response.php
+++ b/src/Response.php
@@ -14,6 +14,7 @@ use Inertia\Contracts\Arrayable;
 use Inertia\Contracts\IgnoreFirstLoad;
 use Inertia\Contracts\InvokableProp;
 use Inertia\Contracts\Mergeable;
+use Inertia\Contracts\Onceable;
 use Inertia\Contracts\ProvidesInertiaProperties;
 use Inertia\Contracts\ProvidesInertiaProperty;
 use Inertia\Props\AlwaysProp;
@@ -104,6 +105,7 @@ final class Response implements HttpResponse
                 $this->resolveDeferredProps(),
                 $this->resolveCacheDirections(),
                 $this->resolveScrollProps(),
+                $this->resolveOnceProps(),
                 $this->resolveFlashData(),
             );
 
@@ -184,6 +186,7 @@ final class Response implements HttpResponse
     public function resolveProperties(array $props): array
     {
         $props = $this->resolvePartialProperties($props);
+        $props = $this->resolveOnceProperties($props);
         $props = $this->resolveAlways($props);
 
         return $this->resolvePropertyInstances($props);
@@ -229,8 +232,8 @@ final class Response implements HttpResponse
             return array_filter($props, static fn ($prop) => ! $prop instanceof IgnoreFirstLoad);
         }
 
-        $only = $this->parsePartialHeader(Header::PARTIAL_ONLY);
-        $except = $this->parsePartialHeader(Header::PARTIAL_EXCEPT);
+        $only = $this->parseHeaderAsArray(Header::PARTIAL_ONLY);
+        $except = $this->parseHeaderAsArray(Header::PARTIAL_EXCEPT);
 
         if ($only !== []) {
             $newProps = [];
@@ -253,6 +256,49 @@ final class Response implements HttpResponse
         }
 
         return $props;
+    }
+
+    /**
+     *  Resolve properties that should only be resolved once.
+     *
+     * @param array<string, mixed> $props
+     * @return array<string, mixed>
+     */
+    public function resolveOnceProperties(array $props): array
+    {
+        $isInertia = (bool) $this->request->headers->get(Header::INERTIA);
+        $isPartial = $this->isPartial();
+
+        if (! $isInertia || $isPartial) {
+            return $props;
+        }
+
+        $exceptOnceProps = $this->parseHeaderAsArray(Header::EXCEPT_ONCE_PROPS);
+
+        if ($exceptOnceProps === []) {
+            return $props;
+        }
+
+        return array_filter(
+            $props,
+            static function (mixed $prop, string $key) use ($exceptOnceProps): bool {
+                if (! $prop instanceof Onceable) {
+                    return true;
+                }
+
+                if (! $prop->shouldResolveOnce()) {
+                    return true;
+                }
+
+                if ($prop->shouldBeRefreshed()) {
+                    return true;
+                }
+
+                $identifier = $prop->getKey() ?? $key;
+                return ! in_array($identifier, $exceptOnceProps, true);
+            },
+            ARRAY_FILTER_USE_BOTH,
+        );
     }
 
     /**
@@ -356,36 +402,36 @@ final class Response implements HttpResponse
     }
 
     /**
-     * Get the props that should be reset based on the request headers.
-     *
-     * @return array<int, string>
-     */
-    public function getResetProps(): array
-    {
-        return array_filter(explode(',', $this->request->headers->get(Header::RESET) ?? ''));
-    }
-
-    /**
      * Resolve merge props configuration for client-side prop merging.
      *
      * @return array<string, mixed>
      */
     public function getMergePropsForRequest(bool $rejectResetProps = true): array
     {
-        $resetProps = $rejectResetProps ? $this->getResetProps() : [];
-        $onlyProps = $this->parsePartialHeader(Header::PARTIAL_ONLY);
-        $exceptProps = $this->parsePartialHeader(Header::PARTIAL_EXCEPT);
-
-        return Arr\filter(
+        $props = array_filter(
             $this->props,
-            static fn ($prop, $key) => (
-                $prop instanceof Mergeable
-                && $prop->shouldMerge()
-                && ! in_array($key, $resetProps, true)
-                && ($onlyProps === [] || in_array($key, $onlyProps, true))
-                && ! in_array($key, $exceptProps, true)
-            ),
+            static fn ($prop) => $prop instanceof Mergeable && $prop->shouldMerge(),
+            ARRAY_FILTER_USE_BOTH,
         );
+
+        if ($rejectResetProps) {
+            $resetProps = $this->parseHeaderAsArray(Header::RESET);
+            if ($resetProps !== []) {
+                $props = array_diff_key($props, array_flip($resetProps));
+            }
+        }
+
+        $onlyProps = $this->parseHeaderAsArray(Header::PARTIAL_ONLY);
+        if ($onlyProps !== []) {
+            $props = array_intersect_key($props, array_flip($onlyProps));
+        }
+
+        $exceptProps = $this->parseHeaderAsArray(Header::PARTIAL_EXCEPT);
+        if ($exceptProps !== []) {
+            return array_diff_key($props, array_flip($exceptProps));
+        }
+
+        return $props;
     }
 
     /**
@@ -452,10 +498,20 @@ final class Response implements HttpResponse
             return [];
         }
 
-        $groupedProps = [];
+        $exceptOnceProps = $this->parseHeaderAsArray(Header::EXCEPT_ONCE_PROPS);
 
+        $groupedProps = [];
         foreach ($this->props as $key => $prop) {
             if (! $prop instanceof DeferProp) {
+                continue;
+            }
+
+            if (
+                $prop instanceof Onceable
+                && $prop->shouldResolveOnce()
+                && ! $prop->shouldBeRefreshed()
+                && in_array($prop->getKey() ?? $key, $exceptOnceProps, true)
+            ) {
                 continue;
             }
 
@@ -473,7 +529,7 @@ final class Response implements HttpResponse
      */
     public function resolveScrollProps(): array
     {
-        $resetProps = $this->getResetProps();
+        $resetProps = $this->parseHeaderAsArray(Header::RESET);
         $scrollPropsResult = [];
 
         foreach ($this->getMergePropsForRequest(false) as $key => $prop) {
@@ -492,6 +548,41 @@ final class Response implements HttpResponse
         }
 
         return ['scrollProps' => $scrollPropsResult];
+    }
+
+    /**
+     * Resolve props that should only be resolved once.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function resolveOnceProps(): array
+    {
+        $props = array_filter(
+            $this->props,
+            static fn ($prop) => $prop instanceof Onceable && $prop->shouldResolveOnce(),
+            ARRAY_FILTER_USE_BOTH,
+        );
+
+        $only = $this->parseHeaderAsArray(Header::PARTIAL_ONLY);
+        if ($only !== []) {
+            $props = array_intersect_key($props, array_flip($only));
+        }
+
+        $except = $this->parseHeaderAsArray(Header::PARTIAL_EXCEPT);
+        if ($except !== []) {
+            $props = array_diff_key($props, array_flip($except));
+        }
+
+        $mapped = [];
+        foreach ($props as $key => $prop) {
+            /** @var Onceable $prop */
+            $mapped[$prop->getKey() ?? $key] = [
+                'prop' => $key,
+                'expiresAt' => $prop->expiresAt(),
+            ];
+        }
+
+        return $mapped !== [] ? ['onceProps' => $mapped] : [];
     }
 
     /**
@@ -586,7 +677,6 @@ final class Response implements HttpResponse
         }
 
         $url = $this->request->uri;
-
         $prefix = $this->request->headers->get(Header::FORWARDED_PREFIX);
 
         if ($prefix) {
@@ -598,11 +688,11 @@ final class Response implements HttpResponse
     }
 
     /**
-     * Parses an Inertia header that contains a comma-separated list of prop keys.
+     * Parses a comma-separated request header into an array of strings.
      *
      * @return string[]
      */
-    private function parsePartialHeader(string $name): array
+    private function parseHeaderAsArray(string $name): array
     {
         $headerValue = $this->request->headers->get($name) ?? '';
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -15,6 +15,7 @@ use Inertia\Props\AlwaysProp;
 use Inertia\Props\DeferProp;
 use Inertia\Props\LazyProp;
 use Inertia\Props\MergeProp;
+use Inertia\Props\OnceProp;
 use Inertia\Props\OptionalProp;
 use Inertia\Props\ScrollProp;
 use Inertia\Support\Header;
@@ -251,6 +252,29 @@ final class ResponseFactory
             wrapper: $wrapper,
             metadata: $metadata,
         );
+    }
+
+    /**
+     * Create a once property.
+     */
+    public function once(callable $value): OnceProp
+    {
+        return new OnceProp($value);
+    }
+
+    /**
+     * Create and share a once property.
+     */
+    public function shareOnce(string $key, callable $callback): OnceProp
+    {
+        $prop = new OnceProp($callback);
+
+        $this->share(
+            key: $key,
+            value: $prop,
+        );
+
+        return $prop;
     }
 
     /**

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -257,9 +257,9 @@ final class ResponseFactory
     /**
      * Create a once property.
      */
-    public function once(callable $value): OnceProp
+    public function once(callable $callback): OnceProp
     {
-        return new OnceProp($value);
+        return new OnceProp($callback);
     }
 
     /**

--- a/src/Support/Header.php
+++ b/src/Support/Header.php
@@ -49,12 +49,12 @@ final readonly class Header
     /**
      * Header for specifying the merge intent when paginating on infinite scroll.
      */
-    public const string INFINITE_SCROLL_MERGE_INTENT = 'X-Inertia-Infinite-Scroll-Merge-Intent';
+    public const string INFINITE_SCROLL_MERGE_INTENT = 'x-inertia-infinite-scroll-merge-intent';
 
     /**
      * Header specifying which once props to exclude from the response.
      */
-    public const string EXCEPT_ONCE_PROPS = 'X-Inertia-Except-Once-Props';
+    public const string EXCEPT_ONCE_PROPS = 'x-inertia-except-once-props';
 
     /**
      * Header for forwarded prefix.

--- a/src/Support/Header.php
+++ b/src/Support/Header.php
@@ -47,12 +47,17 @@ final readonly class Header
     public const string RESET = 'x-inertia-reset';
 
     /**
-     * Header for forwarded prefix.
-     */
-    public const string FORWARDED_PREFIX = 'x-forwarded-prefix';
-
-    /**
      * Header for specifying the merge intent when paginating on infinite scroll.
      */
     public const string INFINITE_SCROLL_MERGE_INTENT = 'X-Inertia-Infinite-Scroll-Merge-Intent';
+
+    /**
+     * Header specifying which once props to exclude from the response.
+     */
+    public const string EXCEPT_ONCE_PROPS = 'X-Inertia-Except-Once-Props';
+
+    /**
+     * Header for forwarded prefix.
+     */
+    public const string FORWARDED_PREFIX = 'x-forwarded-prefix';
 }

--- a/src/Traits/ResolvesOnce.php
+++ b/src/Traits/ResolvesOnce.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Traits;
+
+use BackedEnum;
+use Tempest\DateTime\DateTime;
+use Tempest\DateTime\Duration;
+use UnitEnum;
+
+trait ResolvesOnce
+{
+    /**
+     * Indicates if the prop should be resolved only once.
+     */
+    protected bool $once = false;
+
+    /**
+     * Indicates if the prop should be forcefully refreshed.
+     */
+    protected bool $refresh = false;
+
+    /**
+     * The expiration time in seconds.
+     */
+    protected ?int $ttl = null;
+
+    /**
+     * The custom key for resolving the once prop.
+     */
+    protected ?string $key = null;
+
+    /**
+     * Mark the prop to be resolved only once.
+     */
+    public function once(bool $value = true, ?string $as = null, Duration|int|null $until = null): static
+    {
+        $this->once = $value;
+
+        if ($as !== null) {
+            $this->as($as);
+        }
+
+        if ($until !== null) {
+            $this->until($until);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Determine if the prop should be resolved only once.
+     */
+    public function shouldResolveOnce(): bool
+    {
+        return $this->once;
+    }
+
+    /**
+     * Determine if the prop should be forcefully refreshed.
+     */
+    public function shouldBeRefreshed(): bool
+    {
+        return $this->refresh;
+    }
+
+    /**
+     * Get the custom key for resolving the once prop.
+     */
+    public function getKey(): ?string
+    {
+        return $this->key;
+    }
+
+    /**
+     * Set a custom key for resolving the once prop.
+     */
+    public function as(BackedEnum|UnitEnum|string $key): static
+    {
+        $this->key = match (true) {
+            $key instanceof BackedEnum => $key->value,
+            $key instanceof UnitEnum => $key->name,
+            default => $key,
+        };
+
+        return $this;
+    }
+
+    /**
+     * Mark the property to be forcefully sent to the client.
+     */
+    public function fresh(bool $value = true): static
+    {
+        $this->refresh = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the expiration for the once prop.
+     */
+    public function until(Duration|int $delay): static
+    {
+        $this->ttl = $delay instanceof Duration ? (int) $delay->getTotalSeconds() : $delay;
+
+        return $this;
+    }
+
+    /**
+     * Get the expiration timestamp in milliseconds for the once prop.
+     */
+    public function expiresAt(): ?int
+    {
+        if ($this->ttl === null) {
+            return null;
+        }
+
+        return DateTime::now()
+            ->plusSeconds((int) $this->ttl)
+            ->getTimestamp()
+            ->getMilliseconds();
+    }
+
+    /**
+     * Get the UNIX timestamp.
+     */
+    private function availableAt(Duration|int $delay): int
+    {
+        return DateTime::now()
+            ->plusSeconds((int) $delay)
+            ->getTimestamp()
+            ->getSeconds();
+    }
+}

--- a/tests/Fixtures/BackedEnum.php
+++ b/tests/Fixtures/BackedEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Tests\Fixtures;
+
+enum BackedEnum: string
+{
+    case Foo = 'foo-value';
+}

--- a/tests/Fixtures/RootViewMethodMiddleware.php
+++ b/tests/Fixtures/RootViewMethodMiddleware.php
@@ -37,4 +37,16 @@ final class RootViewMethodMiddleware extends Middleware
     {
         return 'welcome';
     }
+
+    #[Override]
+    public function shareOnce(): array
+    {
+        return [
+            'permissions' => static fn () => ['admin' => true],
+            'settings' => $this->inertia
+                ->once(static fn () => ['theme' => 'dark'])
+                ->as('app-settings')
+                ->until(60),
+        ];
+    }
 }

--- a/tests/Fixtures/UnitEnum.php
+++ b/tests/Fixtures/UnitEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Tests\Fixtures;
+
+enum UnitEnum
+{
+    case Baz;
+}

--- a/tests/Integration/DeferPropTest.php
+++ b/tests/Integration/DeferPropTest.php
@@ -36,7 +36,8 @@ final class DeferPropTest extends TestCase
         $this->assertInstanceOf(Request::class, $deferProp());
     }
 
-    public function test_is_onceable(): void
+    #[Test]
+    public function is_onceable(): void
     {
         $deferProp = new DeferProp(static fn () => 'value')->once(
             as: 'custom-key',

--- a/tests/Integration/DeferPropTest.php
+++ b/tests/Integration/DeferPropTest.php
@@ -35,4 +35,16 @@ final class DeferPropTest extends TestCase
 
         $this->assertInstanceOf(Request::class, $deferProp());
     }
+
+    public function test_is_onceable(): void
+    {
+        $deferProp = new DeferProp(static fn () => 'value')->once(
+            as: 'custom-key',
+            until: 60,
+        );
+
+        $this->assertTrue($deferProp->shouldResolveOnce());
+        $this->assertSame('custom-key', $deferProp->getKey());
+        $this->assertNotNull($deferProp->expiresAt());
+    }
 }

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -374,6 +374,41 @@ final class MiddlewareTest extends TestCase
     }
 
     #[Test]
+    public function middleware_share_once(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRenderWithRootViewMethodMiddleware']),
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $page = $response->body;
+
+        $this->assertSame(['admin' => true], $page['props']['permissions']);
+        $this->assertSame(['theme' => 'dark'], $page['props']['settings']);
+        $this->assertSame(['prop' => 'permissions', 'expiresAt' => null], $page['onceProps']['permissions']);
+        $this->assertSame('settings', $page['onceProps']['app-settings']['prop']);
+        $this->assertNotNull($page['onceProps']['app-settings']['expiresAt']);
+    }
+
+    #[Test]
+    public function middleware_share_and_share_once_are_merged(): void
+    {
+        $response = $this->http->get(
+            uri: uri([TestController::class, 'basicRenderWithRootViewMethodMiddleware']),
+            headers: [Header::INERTIA => 'true'],
+        );
+
+        $page = $response->body;
+
+        $this->assertSame(['message' => null], $page['props']['flash']);
+        $this->assertSame(['admin' => true], $page['props']['permissions']);
+        $this->assertSame(['theme' => 'dark'], $page['props']['settings']);
+        $this->assertSame(['prop' => 'permissions', 'expiresAt' => null], $page['onceProps']['permissions']);
+        $this->assertSame('settings', $page['onceProps']['app-settings']['prop']);
+        $this->assertNotNull($page['onceProps']['app-settings']['expiresAt']);
+    }
+
+    #[Test]
     public function flash_data_is_preserved_on_non_inertia_redirect(): void
     {
         $firstResponse = $this->http->get(uri: uri([TestController::class, 'actionWithRedirect']));

--- a/tests/Integration/OncePropTest.php
+++ b/tests/Integration/OncePropTest.php
@@ -12,7 +12,7 @@ use Tempest\Http\Request;
 final class OncePropTest extends TestCase
 {
     #[Test]
-    public function test_can_invoke_with_a_callback(): void
+    public function can_invoke_with_a_callback(): void
     {
         $onceProp = new OnceProp(static fn () => 'A once prop value');
 
@@ -20,7 +20,7 @@ final class OncePropTest extends TestCase
     }
 
     #[Test]
-    public function test_can_resolve_bindings_when_invoked(): void
+    public function can_resolve_bindings_when_invoked(): void
     {
         $onceProp = new OnceProp(static fn (Request $request) => $request);
 

--- a/tests/Integration/OncePropTest.php
+++ b/tests/Integration/OncePropTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Tests\Integration;
+
+use Inertia\Props\OnceProp;
+use Inertia\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Http\Request;
+
+final class OncePropTest extends TestCase
+{
+    #[Test]
+    public function test_can_invoke_with_a_callback(): void
+    {
+        $onceProp = new OnceProp(static fn () => 'A once prop value');
+
+        $this->assertSame('A once prop value', $onceProp());
+    }
+
+    #[Test]
+    public function test_can_resolve_bindings_when_invoked(): void
+    {
+        $onceProp = new OnceProp(static fn (Request $request) => $request);
+
+        $this->assertInstanceOf(Request::class, $onceProp());
+    }
+}

--- a/tests/Integration/OncePropTest.php
+++ b/tests/Integration/OncePropTest.php
@@ -12,7 +12,7 @@ use Tempest\Http\Request;
 final class OncePropTest extends TestCase
 {
     #[Test]
-    public function can_invoke_with_a_callback(): void
+    public function can_invoke(): void
     {
         $onceProp = new OnceProp(static fn () => 'A once prop value');
 

--- a/tests/Integration/OptionalPropTest.php
+++ b/tests/Integration/OptionalPropTest.php
@@ -26,4 +26,17 @@ final class OptionalPropTest extends TestCase
 
         $this->assertInstanceOf(Request::class, $optionalProp());
     }
+
+    #[Test]
+    public function is_onceable(): void
+    {
+        $optionalProp = new OptionalProp(static fn () => 'value')
+            ->once()
+            ->as('custom-key')
+            ->until(60);
+
+        $this->assertTrue($optionalProp->shouldResolveOnce());
+        $this->assertSame('custom-key', $optionalProp->getKey());
+        $this->assertNotNull($optionalProp->expiresAt());
+    }
 }

--- a/tests/Integration/ResponseFactoryTest.php
+++ b/tests/Integration/ResponseFactoryTest.php
@@ -214,7 +214,8 @@ final class ResponseFactoryTest extends TestCase
         $this->assertSame([], inertia()->getShared());
     }
 
-    public function test_can_create_deferred_prop(): void
+    #[Test]
+    public function can_create_deferred_prop(): void
     {
         $deferredProp = $this->factory->defer(static fn (): string => 'A deferred value');
 
@@ -230,7 +231,7 @@ final class ResponseFactoryTest extends TestCase
     }
 
     #[Test]
-    public function test_response_factory_once_creates_working_once_prop(): void
+    public function response_factory_once_creates_working_once_prop(): void
     {
         $once = $this->factory->once(static fn () => ['theme' => 'dark']);
 

--- a/tests/Integration/ResponseFactoryTest.php
+++ b/tests/Integration/ResponseFactoryTest.php
@@ -214,8 +214,7 @@ final class ResponseFactoryTest extends TestCase
         $this->assertSame([], inertia()->getShared());
     }
 
-    #[Test]
-    public function can_create_deferred_prop(): void
+    public function test_can_create_deferred_prop(): void
     {
         $deferredProp = $this->factory->defer(static fn (): string => 'A deferred value');
 
@@ -228,6 +227,14 @@ final class ResponseFactoryTest extends TestCase
         $deferredProp = $this->factory->defer(static fn (): string => 'A deferred value', 'foo');
 
         $this->assertSame('foo', $deferredProp->group());
+    }
+
+    #[Test]
+    public function test_response_factory_once_creates_working_once_prop(): void
+    {
+        $once = $this->factory->once(static fn () => ['theme' => 'dark']);
+
+        $this->assertSame(['theme' => 'dark'], $once());
     }
 
     #[Test]

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -9,6 +9,7 @@ use Inertia\Configs\InertiaConfig;
 use Inertia\Contracts\Arrayable;
 use Inertia\Contracts\ProvidesInertiaProperties;
 use Inertia\Contracts\ProvidesScrollMetadata;
+use Inertia\Inertia;
 use Inertia\Props\AlwaysProp;
 use Inertia\Props\DeferProp;
 use Inertia\Props\LazyProp;
@@ -24,6 +25,8 @@ use Iterator;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Tempest\DateTime\DateTime;
+use Tempest\DateTime\Duration;
 use Tempest\Http\ContentType;
 use Tempest\Support\Paginator\PaginatedData;
 use Tempest\Support\Paginator\Paginator;
@@ -576,6 +579,29 @@ final class ResponseTest extends TestCase
         $this->assertSame('Jonathan', $page['props']['user']->name);
         $this->assertSame('/user/123', $page['url']);
         $this->assertSame('123', $page['version']);
+    }
+
+    #[Test]
+    public function xhr_response_with_deferred_props_includes_deferred_metadata(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'user' => ['name' => 'Jonathan'],
+                'results' => new DeferProp(static fn () => ['data' => ['item1', 'item2']], 'default'),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertArrayNotHasKey('results', $page['props']);
+        $this->assertSame(['default' => ['results']], $page['deferredProps']);
     }
 
     #[Test]
@@ -1163,6 +1189,302 @@ final class ResponseTest extends TestCase
     }
 
     #[Test]
+    public function once_props_are_always_resolved_on_initial_page_load(): void
+    {
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar'),
+            ],
+        );
+
+        $page = $response->body->inertia['page'];
+
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function fresh_once_props_are_included_on_initial_page_load(): void
+    {
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar')->fresh(),
+            ],
+        );
+
+        $page = $response->body->inertia['page'];
+
+        $this->assertArrayHasKey('onceProps', $page);
+        $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function once_props_are_resolved_with_a_custom_key_and_ttl_value(): void
+    {
+        $clock = $this->clock();
+        $clock->setNow('2025-01-01 12:00:00');
+
+        $expiresAt = DateTime::now()
+            ->plus(Duration::minute())
+            ->getTimestamp()
+            ->getMilliseconds();
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar')->as('baz')->until(Duration::minute()),
+            ],
+        );
+
+        $page = $response->body->inertia['page'];
+
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame(['baz' => ['prop' => 'foo', 'expiresAt' => $expiresAt]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function once_props_are_not_resolved_on_subsequent_requests_when_they_are_in_the_once_props_header(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::EXCEPT_ONCE_PROPS => 'foo',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar'),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function once_props_are_resolved_on_subsequent_requests_when_the_once_props_header_is_missing(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar'),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function once_props_are_resolved_on_subsequent_requests_when_they_are_not_in_the_once_props_header(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::EXCEPT_ONCE_PROPS => 'baz',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar'),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function once_props_are_resolved_on_partial_requests_without_only_or_except(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'foo',
+            Header::EXCEPT_ONCE_PROPS => 'foo',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar'),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function once_props_are_resolved_on_partial_requests_when_included_in_only_headers(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'foo',
+            Header::EXCEPT_ONCE_PROPS => 'foo',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar'),
+                'baz' => inertia()->once(static fn () => 'qux'),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertArrayNotHasKey('baz', $page['props']);
+        $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function once_props_are_not_resolved_on_partial_requests_when_excluded_in_except_headers(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_EXCEPT => 'foo',
+            Header::EXCEPT_ONCE_PROPS => 'foo',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar'),
+                'baz' => inertia()->once(static fn () => 'qux'),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertSame('qux', $page['props']['baz']);
+        $this->assertSame(['baz' => ['prop' => 'baz', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function fresh_props_are_resolved_even_when_in_except_once_props_header(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::EXCEPT_ONCE_PROPS => 'foo',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar')->fresh(),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function fresh_props_are_not_excluded_while_once_props_are_excluded(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::EXCEPT_ONCE_PROPS => 'foo,baz',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => inertia()->once(static fn () => 'bar')->fresh(),
+                'baz' => inertia()->once(static fn () => 'qux'),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertArrayNotHasKey('baz', $page['props']);
+        $this->assertSame(
+            [
+                'foo' => ['prop' => 'foo', 'expiresAt' => null],
+                'baz' => ['prop' => 'baz', 'expiresAt' => null],
+            ],
+            $page['onceProps'],
+        );
+    }
+
+    #[Test]
+    public function defer_props_that_are_once_and_already_loaded_are_excluded(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::EXCEPT_ONCE_PROPS => 'defer',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'defer' => inertia()->defer(static fn () => 'value')->once(),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertArrayNotHasKey('defer', $page['props']);
+        $this->assertArrayNotHasKey('deferredProps', $page);
+        $this->assertSame(['defer' => ['prop' => 'defer', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
+    public function defer_props_that_are_once_and_already_loaded_not_excluded_when_explicitly_requested(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'defer',
+            Header::EXCEPT_ONCE_PROPS => 'defer',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'defer' => inertia()->defer(static fn () => 'value')->once(),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('value', $page['props']['defer']);
+        $this->assertSame(['defer' => ['prop' => 'defer', 'expiresAt' => null]], $page['onceProps']);
+    }
+
+    #[Test]
     public function responsable_with_invalid_key(): void
     {
         $this->makeRequest(headers: [Header::INERTIA => 'true']);
@@ -1186,7 +1508,6 @@ final class ResponseTest extends TestCase
         ]);
 
         $page = $response->body->inertia['page'];
-        $resolvedBody = $response->body->jsonSerialize();
 
         $this->assertSame('/sub/directory/user/123', $page['url']);
     }
@@ -1363,6 +1684,31 @@ final class ResponseTest extends TestCase
         $this->assertSame('Jonathan', $page['props']['user']['name']);
         $this->assertSame('foo value', $page['props']['foo']);
         $this->assertSame(['foo'], $page['mergeProps']);
+    }
+
+    #[Test]
+    public function once_props_from_provides_inertia_properties_are_included_in_once_props_metadata(): void
+    {
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'user' => ['name' => 'Jonathan'],
+                new class implements ProvidesInertiaProperties {
+                    public function toInertiaProperties(RenderContext $context): iterable
+                    {
+                        return [
+                            'foo' => Inertia::once(static fn () => 'bar'),
+                        ];
+                    }
+                },
+            ],
+        );
+
+        $page = $response->body->inertia['page'];
+
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
     }
 
     #[Test]

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -61,6 +61,7 @@ abstract class TestCase extends IntegrationTest
             uri: $uri,
             headers: $headers,
         );
+
         $this->container->singleton(Request::class, static fn () => $request);
 
         return $request;

--- a/tests/Unit/MergePropTest.php
+++ b/tests/Unit/MergePropTest.php
@@ -179,4 +179,17 @@ final class MergePropTest extends TestCase
 
         $this->assertSame(['key', 'anotherKey'], $mergeProp->matchesOn());
     }
+
+    #[Test]
+    public function is_onceable(): void
+    {
+        $mergeProp = new MergeProp(static fn () => [])
+            ->once()
+            ->as('custom-key')
+            ->until(60);
+
+        $this->assertTrue($mergeProp->shouldResolveOnce());
+        $this->assertSame('custom-key', $mergeProp->getKey());
+        $this->assertNotNull($mergeProp->expiresAt());
+    }
 }

--- a/tests/Unit/OncePropTest.php
+++ b/tests/Unit/OncePropTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 final class OncePropTest extends TestCase
 {
     #[Test]
-    public function test_can_set_custom_key(): void
+    public function can_set_custom_key(): void
     {
         $onceProp = new OnceProp(static fn () => 'value');
 

--- a/tests/Unit/OncePropTest.php
+++ b/tests/Unit/OncePropTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Tests\Unit;
+
+use Inertia\Props\OnceProp;
+use Inertia\Tests\Fixtures\BackedEnum;
+use Inertia\Tests\Fixtures\UnitEnum;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OncePropTest extends TestCase
+{
+    #[Test]
+    public function test_can_set_custom_key(): void
+    {
+        $onceProp = new OnceProp(static fn () => 'value');
+
+        $result = $onceProp->as('custom-key');
+        $this->assertSame($onceProp, $result);
+        $this->assertSame('custom-key', $onceProp->getKey());
+
+        $onceProp->as(BackedEnum::Foo);
+        $this->assertSame('foo-value', $onceProp->getKey());
+
+        $onceProp->as(UnitEnum::Baz);
+        $this->assertSame('Baz', $onceProp->getKey());
+    }
+
+    #[Test]
+    public function should_not_be_refreshed_by_default(): void
+    {
+        $onceProp = new OnceProp(static fn () => 'value');
+
+        $this->assertFalse($onceProp->shouldBeRefreshed());
+    }
+
+    #[Test]
+    public function can_forcefully_refresh(): void
+    {
+        $onceProp = new OnceProp(static fn () => 'value');
+        $onceProp->fresh();
+
+        $this->assertTrue($onceProp->shouldBeRefreshed());
+    }
+
+    #[Test]
+    public function can_disable_forceful_refresh(): void
+    {
+        $onceProp = new OnceProp(static fn () => 'value');
+        $onceProp->fresh();
+        $onceProp->fresh(false);
+
+        $this->assertFalse($onceProp->shouldBeRefreshed());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added support for "once properties" that resolve only once with optional custom keys and expiration timestamps
  * New `once()` method to define and configure properties with one-time resolution behavior
  * Added `shareOnce()` in middleware for sharing one-time properties across requests
  * Properties can be configured with custom keys and time-to-live (TTL) expiration values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->