### PR TITLE
feat: allow `ScrollProp` to be deferred

### DIFF
--- a/src/Contracts/Deferrable.php
+++ b/src/Contracts/Deferrable.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Contracts;
+
+interface Deferrable
+{
+    /**
+     * Determine if this property should be deferred.
+     */
+    public function shouldDefer(): bool;
+
+    /**
+     * Get the defer group for this property.
+     */
+    public function group(): string;
+}

--- a/src/Props/DeferProp.php
+++ b/src/Props/DeferProp.php
@@ -4,17 +4,20 @@ declare(strict_types=1);
 
 namespace Inertia\Props;
 
+use Inertia\Contracts\Deferrable;
 use Inertia\Contracts\IgnoreFirstLoad;
 use Inertia\Contracts\InvokableProp;
 use Inertia\Contracts\Mergeable;
 use Inertia\Contracts\Onceable;
+use Inertia\Traits\DefersProps;
 use Inertia\Traits\MergesProps;
 use Inertia\Traits\ResolvesCallables;
 use Inertia\Traits\ResolvesOnce;
 use Override;
 
-final class DeferProp implements IgnoreFirstLoad, Mergeable, Onceable, InvokableProp
+final class DeferProp implements Deferrable, IgnoreFirstLoad, Mergeable, Onceable, InvokableProp
 {
+    use DefersProps;
     use MergesProps;
     use ResolvesCallables;
     use ResolvesOnce;
@@ -29,21 +32,11 @@ final class DeferProp implements IgnoreFirstLoad, Mergeable, Onceable, Invokable
      * from the initial page load and only evaluated when requested by the
      * frontend, improving initial page performance.
      */
-    public function __construct(
-        callable $callback,
-        private readonly string $group = 'default',
-    ) {
-        $this->callback = $callback;
-    }
-
-    /**
-     * Get the defer group for this property. Properties with the same group
-     * are loaded together in a single request, allowing for efficient
-     * batching of related deferred data.
-     */
-    public function group(): ?string
+    public function __construct(callable $callback, string $group = 'default')
     {
-        return $this->group;
+        $this->callback = $callback;
+        $this->deferred = true;
+        $this->deferGroup = $group;
     }
 
     /**

--- a/src/Props/ScrollProp.php
+++ b/src/Props/ScrollProp.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Inertia\Props;
 
+use Inertia\Contracts\Deferrable;
 use Inertia\Contracts\InvokableProp;
 use Inertia\Contracts\Mergeable;
 use Inertia\Contracts\ProvidesScrollMetadata;
 use Inertia\Support\Header;
 use Inertia\Support\ScrollMetadata;
+use Inertia\Traits\DefersProps;
 use Inertia\Traits\MergesProps;
 use Inertia\Traits\ResolvesCallables;
 use Override;
@@ -22,8 +24,9 @@ use function Tempest\get;
  * This class provides functionality for handling pagination data with merge capabilities,
  * allowing paginated content to be appended or prepended during client-side navigation.
  */
-final class ScrollProp implements Mergeable, InvokableProp
+final class ScrollProp implements Deferrable, Mergeable, InvokableProp
 {
+    use DefersProps;
     use MergesProps;
     use ResolvesCallables;
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -11,6 +11,7 @@ use DateTimeImmutable;
 use GuzzleHttp\Promise\PromiseInterface;
 use Inertia\Configs\InertiaConfig;
 use Inertia\Contracts\Arrayable;
+use Inertia\Contracts\Deferrable;
 use Inertia\Contracts\IgnoreFirstLoad;
 use Inertia\Contracts\InvokableProp;
 use Inertia\Contracts\Mergeable;
@@ -18,7 +19,6 @@ use Inertia\Contracts\Onceable;
 use Inertia\Contracts\ProvidesInertiaProperties;
 use Inertia\Contracts\ProvidesInertiaProperty;
 use Inertia\Props\AlwaysProp;
-use Inertia\Props\DeferProp;
 use Inertia\Props\ScrollProp;
 use Inertia\Ssr\Contracts\Gateway;
 use Inertia\Ssr\Response as SsrResponse;
@@ -229,7 +229,12 @@ final class Response implements HttpResponse
     public function resolvePartialProperties(array $props): array
     {
         if (! $this->isPartial()) {
-            return array_filter($props, static fn ($prop) => ! $prop instanceof IgnoreFirstLoad);
+            return array_filter(
+                $props,
+                static fn ($prop) => (
+                    ! $prop instanceof IgnoreFirstLoad && ! ($prop instanceof Deferrable && $prop->shouldDefer())
+                ),
+            );
         }
 
         $only = $this->parseHeaderAsArray(Header::PARTIAL_ONLY);
@@ -281,21 +286,8 @@ final class Response implements HttpResponse
 
         return array_filter(
             $props,
-            static function (mixed $prop, string $key) use ($exceptOnceProps): bool {
-                if (! $prop instanceof Onceable) {
-                    return true;
-                }
-
-                if (! $prop->shouldResolveOnce()) {
-                    return true;
-                }
-
-                if ($prop->shouldBeRefreshed()) {
-                    return true;
-                }
-
-                $identifier = $prop->getKey() ?? $key;
-                return ! in_array($identifier, $exceptOnceProps, true);
+            function (mixed $prop, string $key) use ($exceptOnceProps): bool {
+                return ! $this->isExcludedOnce($prop, $key, $exceptOnceProps);
             },
             ARRAY_FILTER_USE_BOTH,
         );
@@ -498,16 +490,15 @@ final class Response implements HttpResponse
 
         $groupedProps = [];
         foreach ($this->props as $key => $prop) {
-            if (! $prop instanceof DeferProp) {
+            if (! $prop instanceof Deferrable) {
                 continue;
             }
 
-            if (
-                $prop instanceof Onceable
-                && $prop->shouldResolveOnce()
-                && ! $prop->shouldBeRefreshed()
-                && in_array($prop->getKey() ?? $key, $exceptOnceProps, true)
-            ) {
+            if (! $prop->shouldDefer()) {
+                continue;
+            }
+
+            if ($this->isExcludedOnce($prop, $key, $exceptOnceProps)) {
                 continue;
             }
 
@@ -526,10 +517,15 @@ final class Response implements HttpResponse
     public function resolveScrollProps(): array
     {
         $resetProps = $this->parseHeaderAsArray(Header::RESET);
-        $scrollPropsResult = [];
+        $isPartial = $this->isPartial();
 
+        $scrollPropsResult = [];
         foreach ($this->getMergePropsForRequest(false) as $key => $prop) {
             if (! $prop instanceof ScrollProp) {
+                continue;
+            }
+
+            if (! $isPartial && $prop->shouldDefer()) {
                 continue;
             }
 
@@ -539,11 +535,7 @@ final class Response implements HttpResponse
             ];
         }
 
-        if ($scrollPropsResult === []) {
-            return [];
-        }
-
-        return ['scrollProps' => $scrollPropsResult];
+        return $scrollPropsResult === [] ? [] : ['scrollProps' => $scrollPropsResult];
     }
 
     /**
@@ -608,6 +600,26 @@ final class Response implements HttpResponse
     private function normalizeProps(array|ArrayInterface $props): array
     {
         return $props instanceof ArrayInterface ? $props->toArray() : $props;
+    }
+
+    /**
+     * Determines if a prop should be excluded because it has already been resolved once.
+     */
+    private function isExcludedOnce(mixed $prop, string $key, array $exceptOnceProps): bool
+    {
+        if (! $prop instanceof Onceable) {
+            return false;
+        }
+
+        if (! $prop->shouldResolveOnce()) {
+            return false;
+        }
+
+        if ($prop->shouldBeRefreshed()) {
+            return false;
+        }
+
+        return in_array($prop->getKey() ?? $key, $exceptOnceProps, true);
     }
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -286,9 +286,7 @@ final class Response implements HttpResponse
 
         return array_filter(
             $props,
-            function (mixed $prop, string $key) use ($exceptOnceProps): bool {
-                return ! $this->isExcludedOnce($prop, $key, $exceptOnceProps);
-            },
+            fn (mixed $prop, string $key) => ! $this->isExcludedOnce($prop, $key, $exceptOnceProps),
             ARRAY_FILTER_USE_BOTH,
         );
     }

--- a/src/Traits/DefersProps.php
+++ b/src/Traits/DefersProps.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Traits;
+
+trait DefersProps
+{
+    /**
+     * Indicates if the property should be deferred.
+     */
+    protected bool $deferred = false;
+
+    /**
+     * The defer group.
+     */
+    protected string $deferGroup = 'default';
+
+    /**
+     * Mark this property as deferred. Deferred properties are excluded
+     * from the initial page load and only evaluated when requested by the
+     * frontend, improving initial page performance.
+     */
+    public function defer(string $group = 'default'): static
+    {
+        $this->deferred = true;
+        $this->deferGroup = $group;
+
+        return $this;
+    }
+
+    /**
+     * Determine if this property should be deferred.
+     */
+    public function shouldDefer(): bool
+    {
+        return $this->deferred;
+    }
+
+    /**
+     * Get the defer group for this property. Properties with the same group
+     * are loaded together in a single request, allowing for efficient
+     * batching of related deferred data.
+     */
+    public function group(): string
+    {
+        return $this->deferGroup;
+    }
+}

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -220,7 +220,8 @@ final class ResponseTest extends TestCase
         );
     }
 
-    public function test_deferred_scroll_prop_is_excluded_from_initial_request(): void
+    #[Test]
+    public function deferred_scroll_prop_is_excluded_from_initial_request(): void
     {
         $response = new Response(
             component: 'Users/Index',

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -18,13 +18,17 @@ use Inertia\Props\ScrollProp;
 use Inertia\Response;
 use Inertia\Support\Header;
 use Inertia\Support\RenderContext;
+use Inertia\Tests\Fixtures\CreateUserTable;
 use Inertia\Tests\Fixtures\FakeResource;
 use Inertia\Tests\Fixtures\TestController;
 use Inertia\Tests\Fixtures\User;
+use Inertia\Tests\Fixtures\UserSeeder;
 use Inertia\Tests\TestCase;
 use Iterator;
 use Mockery;
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreCondition;
 use PHPUnit\Framework\Attributes\Test;
 use Tempest\DateTime\DateTime;
 use Tempest\DateTime\Duration;
@@ -37,6 +41,26 @@ use function Tempest\Router\uri;
 
 final class ResponseTest extends TestCase
 {
+    private static bool $dbInitialized = false;
+
+    #[PreCondition]
+    protected function configure(): void
+    {
+        if (! self::$dbInitialized) {
+            $this->database->setup();
+
+            new UserSeeder()->run(null);
+
+            self::$dbInitialized = true;
+        }
+    }
+
+    #[Override]
+    protected function migrateDatabase(): void
+    {
+        $this->database->migrate(CreateUserTable::class);
+    }
+
     #[Test]
     public function server_response(): void
     {

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -20,6 +20,7 @@ use Inertia\Support\Header;
 use Inertia\Support\RenderContext;
 use Inertia\Tests\Fixtures\FakeResource;
 use Inertia\Tests\Fixtures\TestController;
+use Inertia\Tests\Fixtures\User;
 use Inertia\Tests\TestCase;
 use Iterator;
 use Mockery;
@@ -193,6 +194,62 @@ final class ResponseTest extends TestCase
             ],
             $page['scrollProps'],
         );
+    }
+
+    public function test_deferred_scroll_prop_is_excluded_from_initial_request(): void
+    {
+        $response = new Response(
+            component: 'Users/Index',
+            props: [
+                'users' => new ScrollProp(static fn () => User::select()->paginate(15))->defer(),
+            ],
+        );
+
+        $page = $response->body->inertia['page'];
+
+        $this->assertArrayNotHasKey('users', $page['props']);
+        $this->assertSame(['default' => ['users']], $page['deferredProps']);
+        $this->assertArrayNotHasKey('scrollProps', $page);
+    }
+
+    #[Test]
+    public function deferred_scroll_prop_is_resolved_on_partial_request(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'users',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'users' => new ScrollProp(static fn () => User::select()->paginate(15))->defer(),
+            ],
+        );
+
+        $page = $response->body->jsonSerialize();
+
+        $this->assertArrayHasKey('scrollProps', $page);
+        $this->assertArrayHasKey('users', $page['props']);
+        $this->assertCount(15, $page['props']['users']->data);
+        $this->assertContains('users.data', $page['mergeProps']);
+    }
+
+    #[Test]
+    public function deferred_scroll_prop_can_have_custom_group(): void
+    {
+        $response = new Response(
+            component: 'Users/Index',
+            props: [
+                'users' => new ScrollProp(static fn () => User::select()->paginate(15))->defer('custom-group'),
+            ],
+        );
+
+        $page = $response->body->inertia['page'];
+
+        $this->assertArrayNotHasKey('users', $page['props']);
+        $this->assertSame(['custom-group' => ['users']], $page['deferredProps']);
     }
 
     #[Test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Properties can now be deferred with custom grouping for organized loading
  * Scroll properties support deferred resolution on partial requests
  * Multiple deferred properties can be batched together by group

<!-- end of auto-generated comment: release notes by coderabbit.ai -->