### PR TITLE
chore: allow manual and PR CI runs on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
+    branches: ["*"]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflow now runs on all branches instead of only the main branch
  * Added ability to manually trigger the CI workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->