### PR TITLE
[3.x] refactor!: make script element the default config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ use function Tempest\env;
 return new InertiaConfig(
     // Enforce that page components exist on disk.
     pages: new PageConfig(
-        ensure_pages_exists: env('INERTIA_ENSURE_PAGES_EXIST', false),
+        ensure_pages_exist: env('INERTIA_ENSURE_PAGES_EXIST', false),
     ),
 
     // Enable Laravel's paginator format on the front-end.

--- a/src/Configs/HistoryConfig.php
+++ b/src/Configs/HistoryConfig.php
@@ -5,21 +5,17 @@ declare(strict_types=1);
 namespace Inertia\Configs;
 
 /*
- * |--------------------------------------------------------------------------
- * | History Encryption
- * |--------------------------------------------------------------------------
- * |
- * | Inertia's history encryption protects privileged page data from being
- * | exposed via the browser's back button after logout. When enabled, it
- * | encrypts the current page's state using the browser's SubtleCrypto API
- * | before storing it in the history stack. The encryption key is saved
- * | in sessionStorage. On back navigation, the data is decrypted using
- * | this key. If the key has been cleared (e.g. via `clearHistory()`),
- * | decryption fails and Inertia fetches fresh data from the server.
- * |
- * | Note: Requires a secure context (HTTPS) due to usage of `crypto.subtle`.
- * | For details, visit: https://inertiajs.com/history-encryption
- * |
+ * --------------------------------------------------------------------------
+ * History Encryption
+ * --------------------------------------------------------------------------
+ *
+ * Enable `encrypt` to encrypt page data before it is stored in the
+ * browser's history state, preventing sensitive information from
+ * being accessible after logout. Can also be enabled per-request
+ * or via the `inertia.encrypt` middleware.
+ *
+ * Note: Requires a secure context (HTTPS) due to usage of `crypto.subtle`.
+ * For details, visit: https://inertiajs.com/history-encryption
  */
 final class HistoryConfig
 {

--- a/src/Configs/InertiaConfig.php
+++ b/src/Configs/InertiaConfig.php
@@ -24,7 +24,7 @@ final readonly class InertiaConfig
          * Server Side Rendering
          *--------------------------------------------------------------------------
          *
-         * These options configures if and how Inertia uses Server Side Rendering
+         * These options configure if and how Inertia uses Server Side Rendering
          * to pre-render the initial visits made to your application's pages.
          *
          * You can specify a custom SSR bundle path or omit it to let Inertia

--- a/src/Configs/InertiaConfig.php
+++ b/src/Configs/InertiaConfig.php
@@ -5,97 +5,93 @@ declare(strict_types=1);
 namespace Inertia\Configs;
 
 /*
- * |--------------------------------------------------------------------------
- * | Main Inertia Configuration
- * |--------------------------------------------------------------------------
- * |
- * | This is the main configuration object for the Inertia package. It aggregates
- * | all the other configuration objects for easy access and management.
- * |
- * | Use this within your inertia.config.php file and override specific settings
- * | as needed.
- * |
+ *--------------------------------------------------------------------------
+ * Main Inertia Configuration
+ *--------------------------------------------------------------------------
+ *
+ * This is the main configuration object for the Inertia package. It aggregates
+ * all the other configuration objects for easy access and management.
+ *
+ * Use this within your inertia.config.php file and override specific settings
+ * as needed.
+ *
  */
 final readonly class InertiaConfig
 {
     public function __construct(
         /*
-         * |--------------------------------------------------------------------------
-         * | Server Side Rendering
-         * |--------------------------------------------------------------------------
-         * |
-         * | These options configures if and how Inertia uses Server Side Rendering
-         * | to pre-render the initial visits made to your application's pages.
-         * |
-         * | You can specify a custom SSR bundle path or omit it to let Inertia
-         * | try and automatically detect it for you.
-         * |
-         * | Do note that enabling these options will NOT automatically make SSR work,
-         * | as a separate rendering service needs to be available. For details,
-         * | visit: https://inertiajs.com/server-side-rendering
-         * |
+         *--------------------------------------------------------------------------
+         * Server Side Rendering
+         *--------------------------------------------------------------------------
+         *
+         * These options configures if and how Inertia uses Server Side Rendering
+         * to pre-render the initial visits made to your application's pages.
+         *
+         * You can specify a custom SSR bundle path or omit it to let Inertia
+         * try and automatically detect it for you.
+         *
+         * Do note that enabling these options will NOT automatically make SSR work,
+         * as a separate rendering service needs to be available. For details,
+         * visit: https://inertiajs.com/server-side-rendering
+         *
          */
         public SsrConfig $ssr = new SsrConfig(),
 
         /*
-         * |--------------------------------------------------------------------------
-         * | Pages
-         * |--------------------------------------------------------------------------
-         * |
-         * | Set `ensure_pages_exist` to true if you want to enforce that Inertia page
-         * | components exist on disk when rendering a page. This is useful for
-         * | catching missing or misnamed components.
-         * |
-         * | Not recommended for production use, as it introduces filesystem overhead
-         * | on every request and may impact performance.
-         * |
-         * | The `page_paths` and `page_extensions` options define where to look
-         * | for page components and which file extensions to consider. For
-         * | details, visit: https://inertiajs.com/pages#creating-pages
-         * |
+         *--------------------------------------------------------------------------
+         * Pages
+         *--------------------------------------------------------------------------
+         *
+         * Set `ensure_pages_exist` to true if you want to enforce that Inertia page
+         * components exist on disk when rendering a page. This is useful for
+         * catching missing or misnamed components. Not recommended for
+         * production use.
+         *
+         * The `paths` and `extensions ` options define where to look
+         * for page components and which file extensions to consider.
+         *
+         * By default, the initial page data is passed via a script element.
+         * Set `use_data_attribute_for_initial_page` to true to use a data
+         * attribute on the root element instead.
          */
         public PageConfig $pages = new PageConfig(),
 
         /*
-         * |--------------------------------------------------------------------------
-         * | History Encryption
-         * |--------------------------------------------------------------------------
-         * |
-         * | Inertia's history encryption protects privileged page data from being
-         * | exposed via the browser's back button after logout. When enabled, it
-         * | encrypts the current page's state using the browser's SubtleCrypto API
-         * | before storing it in the history stack. The encryption key is saved
-         * | in sessionStorage. On back navigation, the data is decrypted using
-         * | this key. If the key has been cleared (e.g. via `clearHistory()`),
-         * | decryption fails and Inertia fetches fresh data from the server.
-         * |
-         * | Note: Requires a secure context (HTTPS) due to usage of `crypto.subtle`.
-         * | For details, visit: https://inertiajs.com/history-encryption
-         * |
+         * --------------------------------------------------------------------------
+         * History Encryption
+         * --------------------------------------------------------------------------
+         *
+         * Enable `encrypt` to encrypt page data before it is stored in the
+         * browser's history state, preventing sensitive information from
+         * being accessible after logout. Can also be enabled per-request
+         * or via the `inertia.encrypt` middleware.
+         *
+         * Note: Requires a secure context (HTTPS) due to usage of `crypto.subtle`.
+         * For details, visit: https://inertiajs.com/history-encryption
          */
         public HistoryConfig $history = new HistoryConfig(),
 
         /*
-         * |--------------------------------------------------------------------------
-         * | Validation Error Configuration
-         * |--------------------------------------------------------------------------
-         * |
-         * | These options control how validation errors are formatted and presented
-         * | in the Inertia 'errors' prop.
-         * |
+         *--------------------------------------------------------------------------
+         * Validation Error Configuration
+         *--------------------------------------------------------------------------
+         *
+         * These options control how validation errors are formatted and presented
+         * in the Inertia 'errors' prop.
+         *
          */
         public ValidationConfig $validation = new ValidationConfig(),
 
         /*
-         * |--------------------------------------------------------------------------
-         * | Pagination Transformation
-         * |--------------------------------------------------------------------------
-         * |
-         * | This option determines if Tempest's native paginator objects should be
-         * | automatically transformed into the data/links/meta-structure that is
-         * | standard in the Laravel ecosystem and expected by most Inertia.js
-         * | front-end pagination components.
-         * |
+         *--------------------------------------------------------------------------
+         * Pagination Transformation
+         *--------------------------------------------------------------------------
+         *
+         * This option determines if Tempest's native paginator objects should be
+         * automatically transformed into the data/links/meta-structure that is
+         * standard in the Laravel ecosystem and expected by most Inertia.js
+         * front-end pagination components.
+         *
          */
         public bool $laravel_pagination = false,
     ) {}

--- a/src/Configs/PageConfig.php
+++ b/src/Configs/PageConfig.php
@@ -7,41 +7,41 @@ namespace Inertia\Configs;
 use function Tempest\root_path;
 
 /*
- * |--------------------------------------------------------------------------
- * | Pages
- * |--------------------------------------------------------------------------
- * |
- * | Set `ensure_pages_exist` to true if you want to enforce that Inertia page
- * | components exist on disk when rendering a page. This is useful for
- * | catching missing or misnamed components.
- * |
- * | Not recommended for production use, as it introduces filesystem overhead
- * | on every request and may impact performance.
- * |
- * | The `page_paths` and `page_extensions` options define where to look
- * | for page components and which file extensions to consider. For
- * | details, visit: https://inertiajs.com/pages#creating-pages
- * |
+ *--------------------------------------------------------------------------
+ * Pages
+ *--------------------------------------------------------------------------
+ *
+ * Set `ensure_pages_exist` to true if you want to enforce that Inertia page
+ * components exist on disk when rendering a page. This is useful for
+ * catching missing or misnamed components. Not recommended for
+ * production use.
+ *
+ * The `paths` and `extensions ` options define where to look
+ * for page components and which file extensions to consider.
+ *
+ * By default, the initial page data is passed via a script element.
+ * Set `use_data_attribute_for_initial_page` to true to use a data
+ * attribute on the root element instead.
  */
 final class PageConfig
 {
     public bool $ensure_pages_exists;
 
-    public array $page_paths;
+    public array $paths;
 
-    public array $page_extensions;
+    public array $extensions;
 
-    public bool $use_script_element_for_initial_page;
+    public bool $use_data_attribute_for_initial_page;
 
     public function __construct(
         ?bool $ensure_pages_exists = null,
-        ?array $page_paths = null,
-        ?array $page_extensions = null,
-        ?bool $use_script_element_for_initial_page = null,
+        ?array $paths = null,
+        ?array $extensions = null,
+        ?bool $use_data_attribute_for_initial_page = null,
     ) {
         $this->ensure_pages_exists = $ensure_pages_exists ?? false;
-        $this->page_paths = $page_paths ?? [root_path('app/')];
-        $this->page_extensions = $page_extensions ?? [
+        $this->paths = $paths ?? [root_path('app/')];
+        $this->extensions = $extensions ?? [
             'js',
             'jsx',
             'svelte',
@@ -49,6 +49,6 @@ final class PageConfig
             'tsx',
             'vue',
         ];
-        $this->use_script_element_for_initial_page = $use_script_element_for_initial_page ?? false;
+        $this->use_data_attribute_for_initial_page = $use_data_attribute_for_initial_page ?? false;
     }
 }

--- a/src/Configs/PageConfig.php
+++ b/src/Configs/PageConfig.php
@@ -25,7 +25,7 @@ use function Tempest\root_path;
  */
 final class PageConfig
 {
-    public bool $ensure_pages_exists;
+    public bool $ensure_pages_exist;
 
     public array $paths;
 
@@ -34,12 +34,12 @@ final class PageConfig
     public bool $use_data_attribute_for_initial_page;
 
     public function __construct(
-        ?bool $ensure_pages_exists = null,
+        ?bool $ensure_pages_exist = null,
         ?array $paths = null,
         ?array $extensions = null,
         ?bool $use_data_attribute_for_initial_page = null,
     ) {
-        $this->ensure_pages_exists = $ensure_pages_exists ?? false;
+        $this->ensure_pages_exist = $ensure_pages_exist ?? false;
         $this->paths = $paths ?? [root_path('app/')];
         $this->extensions = $extensions ?? [
             'js',

--- a/src/Configs/SsrConfig.php
+++ b/src/Configs/SsrConfig.php
@@ -12,7 +12,7 @@ use function Tempest\root_path;
  * Server Side Rendering
  *--------------------------------------------------------------------------
  *
- * These options configures if and how Inertia uses Server Side Rendering
+ * These options configure if and how Inertia uses Server Side Rendering
  * to pre-render the initial visits made to your application's pages.
  *
  * You can specify a custom SSR bundle path or omit it to let Inertia

--- a/src/Configs/SsrConfig.php
+++ b/src/Configs/SsrConfig.php
@@ -8,20 +8,20 @@ namespace Inertia\Configs;
 use function Tempest\root_path;
 
 /*
- * |--------------------------------------------------------------------------
- * | Server Side Rendering
- * |--------------------------------------------------------------------------
- * |
- * | These options configures if and how Inertia uses Server Side Rendering
- * | to pre-render the initial visits made to your application's pages.
- * |
- * | You can specify a custom SSR bundle path or omit it to let Inertia
- * | try and automatically detect it for you.
- * |
- * | Do note that enabling these options will NOT automatically make SSR work,
- * | as a separate rendering service needs to be available. For details,
- * | visit: https://inertiajs.com/server-side-rendering
- * |
+ *--------------------------------------------------------------------------
+ * Server Side Rendering
+ *--------------------------------------------------------------------------
+ *
+ * These options configures if and how Inertia uses Server Side Rendering
+ * to pre-render the initial visits made to your application's pages.
+ *
+ * You can specify a custom SSR bundle path or omit it to let Inertia
+ * try and automatically detect it for you.
+ *
+ * Do note that enabling these options will NOT automatically make SSR work,
+ * as a separate rendering service needs to be available. For details,
+ * visit: https://inertiajs.com/server-side-rendering
+ *
  */
 final class SsrConfig
 {

--- a/src/Configs/ValidationConfig.php
+++ b/src/Configs/ValidationConfig.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Inertia\Configs;
 
 /*
- * |--------------------------------------------------------------------------
- * | Validation Error Configuration
- * |--------------------------------------------------------------------------
- * |
- * | These options control how validation errors are formatted and presented
- * | in the Inertia 'errors' prop.
- * |
+ *--------------------------------------------------------------------------
+ * Validation Error Configuration
+ *--------------------------------------------------------------------------
+ *
+ * These options control how validation errors are formatted and presented
+ * in the Inertia 'errors' prop.
+ *
  */
 final class ValidationConfig
 {

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -287,7 +287,7 @@ final class ResponseFactory
             throw new InvalidArgumentException('Component argument must be of type string or a string BackedEnum');
         }
 
-        if ($this->config->pages->ensure_pages_exists) {
+        if ($this->config->pages->ensure_pages_exist) {
             $this->findComponentOrFail($component);
         }
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -388,15 +388,15 @@ final class ResponseFactory
     {
         if (isset($this->componentCache[$component])) {
             if (! $this->componentCache[$component]) {
-                throw new ComponentNotFoundException($component, $this->config->pages->page_paths);
+                throw new ComponentNotFoundException($component, $this->config->pages->paths);
             }
 
             return;
         }
 
         $componentPath = str_replace('/', DIRECTORY_SEPARATOR, $component);
-        $paths = $this->config->pages->page_paths;
-        $extensions = $this->config->pages->page_extensions;
+        $paths = $this->config->pages->paths;
+        $extensions = $this->config->pages->extensions;
 
         foreach ($paths as $path) {
             foreach ($extensions as $extension) {

--- a/src/Views/InertiaView.php
+++ b/src/Views/InertiaView.php
@@ -41,11 +41,11 @@ final class InertiaView implements View
 
         if ($this->ssrBody) {
             $body = $this->ssrBody;
-        } elseif ($this->config->pages->use_script_element_for_initial_page) {
+        } elseif ($this->config->pages->use_data_attribute_for_initial_page) {
+            $body = "<div id=\"{$id}\" data-page=\"{$escaped}\"></div>";
+        } else {
             $body =
                 "<script data-page=\"{$id}\" type=\"application/json\">{$json}</script>" . "<div id=\"{$id}\"></div>";
-        } else {
-            $body = "<div id=\"{$id}\" data-page=\"{$escaped}\"></div>";
         }
 
         return new HtmlString($body);

--- a/tests/Integration/DirectiveTest.php
+++ b/tests/Integration/DirectiveTest.php
@@ -28,26 +28,25 @@ final class DirectiveTest extends TestCase
         );
 
         $expectedJson = json_encode(self::EXAMPLE_PAGE_OBJECT);
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, (string) $view->inertia());
     }
 
     #[Test]
-    public function inertia_directive_renders_the_root_element_and_script_element(): void
+    public function inertia_directive_renders_the_root_element_with_data_attribute(): void
     {
         $this->container->singleton(InertiaConfig::class, static fn () => new InertiaConfig(
             ssr: new SsrConfig(enabled: false),
-            pages: new PageConfig(use_script_element_for_initial_page: true),
+            pages: new PageConfig(use_data_attribute_for_initial_page: true),
         ));
 
         $response = $this->factory->render('Foo/Bar', self::EXAMPLE_PAGE_OBJECT['props']);
         $view = $response->body;
 
         $pageJson = json_encode($view->inertia['page'], JSON_THROW_ON_ERROR);
-
-        $expectedHtml =
-            '<script data-page="app" type="application/json">' . $pageJson . '</script><div id="app"></div>';
+        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($pageJson, ENT_QUOTES) . '"></div>';
 
         $this->assertSame($expectedHtml, (string) $view->inertia());
     }
@@ -89,26 +88,25 @@ final class DirectiveTest extends TestCase
         $view = $response->body;
 
         $expectedJson = '{"component":"Foo\/Bar","props":{"foo":"bar"},"url":"\/","version":"","clearHistory":false,"encryptHistory":false}';
-        $expectedHtml = '<div id="foo" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="foo" type="application/json">' . $expectedJson . '</script><div id="foo"></div>';
 
         $this->assertSame($expectedHtml, (string) $view->inertia('foo'));
     }
 
     #[Test]
-    public function inertia_directive_can_use_a_different_root_element_id_when_using_script_element(): void
+    public function inertia_directive_can_use_a_different_root_element_id_when_using_data_attribute(): void
     {
         $this->container->singleton(InertiaConfig::class, static fn () => new InertiaConfig(
             ssr: new SsrConfig(enabled: false),
-            pages: new PageConfig(use_script_element_for_initial_page: true),
+            pages: new PageConfig(use_data_attribute_for_initial_page: true),
         ));
 
         $response = $this->factory->render('Foo/Bar', self::EXAMPLE_PAGE_OBJECT['props']);
         $view = $response->body;
 
         $pageJson = json_encode($view->inertia['page'], JSON_THROW_ON_ERROR);
-
-        $expectedHtml =
-            '<script data-page="foo" type="application/json">' . $pageJson . '</script><div id="foo"></div>';
+        $expectedHtml = '<div id="foo" data-page="' . htmlspecialchars($pageJson, ENT_QUOTES) . '"></div>';
 
         $this->assertSame($expectedHtml, (string) $view->inertia('foo'));
     }

--- a/tests/Integration/ResponseFactoryTest.php
+++ b/tests/Integration/ResponseFactoryTest.php
@@ -352,7 +352,7 @@ final class ResponseFactoryTest extends TestCase
     {
         $this->container->singleton(
             InertiaConfig::class,
-            static fn () => new InertiaConfig(pages: new PageConfig(ensure_pages_exists: true)),
+            static fn () => new InertiaConfig(pages: new PageConfig(ensure_pages_exist: true)),
         );
 
         $this->expectException(ComponentNotFoundException::class);
@@ -364,8 +364,8 @@ final class ResponseFactoryTest extends TestCase
     #[Test]
     public function will_not_throw_exception_if_component_does_not_exist_when_ensuring_is_disabled(): void
     {
-        $originalEnv = getenv('INERTIA_ENSURE_PAGES_EXISTS');
-        putenv('INERTIA_ENSURE_PAGES_EXISTS=false');
+        $originalEnv = getenv('INERTIA_ENSURE_PAGES_EXIST');
+        putenv('INERTIA_ENSURE_PAGES_EXIST=false');
 
         try {
             $response = $this->container->get(ResponseFactory::class)->render('foo');
@@ -373,9 +373,9 @@ final class ResponseFactoryTest extends TestCase
             $this->assertInstanceOf(Response::class, $response);
         } finally {
             if (! $originalEnv) {
-                putenv('INERTIA_ENSURE_PAGES_EXISTS');
+                putenv('INERTIA_ENSURE_PAGES_EXIST');
             } else {
-                putenv("INERTIA_ENSURE_PAGES_EXISTS={$originalEnv}");
+                putenv("INERTIA_ENSURE_PAGES_EXIST={$originalEnv}");
             }
         }
     }

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -83,7 +83,8 @@ final class ResponseTest extends TestCase
         $this->assertFalse($page['encryptHistory']);
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }
@@ -114,7 +115,8 @@ final class ResponseTest extends TestCase
         $this->assertSame(['default' => ['foo']], $page['deferredProps']);
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo"]}}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }
@@ -155,7 +157,8 @@ final class ResponseTest extends TestCase
         );
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo","bar"],"custom":["baz"]}}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }
@@ -300,7 +303,8 @@ final class ResponseTest extends TestCase
         $this->assertSame(['foo', 'bar'], $page['mergeProps']);
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"]}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }
@@ -331,7 +335,8 @@ final class ResponseTest extends TestCase
         $this->assertFalse($page['encryptHistory']);
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["bar"],"prependProps":["foo"]}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }
@@ -363,7 +368,8 @@ final class ResponseTest extends TestCase
         $this->assertFalse($page['encryptHistory']);
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":{"data":[{"id":1},{"id":2}]},"bar":{"data":{"items":[{"uuid":1},{"uuid":2}]}}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo.data"],"prependProps":["bar.data.items"]}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }
@@ -398,7 +404,8 @@ final class ResponseTest extends TestCase
         $this->assertFalse($page['encryptHistory']);
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":{"data":[{"id":1},{"id":2}]},"bar":{"data":{"items":[{"uuid":1},{"uuid":2}]}}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo.data"],"prependProps":["bar.data.items"],"matchPropsOn":["foo.data.id","bar.data.items.uuid"]}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }
@@ -431,7 +438,8 @@ final class ResponseTest extends TestCase
         $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"]}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }
@@ -469,7 +477,8 @@ final class ResponseTest extends TestCase
         $this->assertSame(['foo.foo-key', 'bar.bar-key'], $page['matchPropsOn']);
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"matchPropsOn":["foo.foo-key","bar.bar-key"]}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }
@@ -503,7 +512,8 @@ final class ResponseTest extends TestCase
         $this->assertSame(['foo', 'bar'], $page['mergeProps']);
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }
@@ -537,7 +547,8 @@ final class ResponseTest extends TestCase
         $this->assertSame(['foo', 'bar'], $page['deepMergeProps']);
 
         $expectedJson = '{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}';
-        $expectedHtml = '<div id="app" data-page="' . htmlspecialchars($expectedJson, ENT_QUOTES) . '"></div>';
+        $expectedHtml =
+            '<script data-page="app" type="application/json">' . $expectedJson . '</script><div id="app"></div>';
 
         $this->assertSame($expectedHtml, $renderer->render($response->body));
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated PageConfig property naming conventions for consistency: simplified to `paths`, `extensions`, and `use_data_attribute_for_initial_page`.

* **Improvements**
  * Enhanced initial page rendering mechanism for improved performance and compatibility.

* **Documentation**
  * Improved configuration documentation and formatting across all configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->