### PR TITLE
Support tempest 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,69 +15,80 @@ jobs:
     name: Validate repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.5"
+          tools: composer:v2
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict
 
   test:
-    name: Run tests (PHP ${{ matrix.php }})
+    name: PHP ${{ matrix.php }} (${{ matrix.stability }})
     needs: lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php: [ "8.5" ]
+        php: ["8.5"]
         stability: ["prefer-lowest", "prefer-stable"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          tools: composer:v2
 
-      - name: Cache Composer packages
-        uses: actions/cache@v3
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer downloads
+        uses: actions/cache@v5
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.stability }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}-
+            ${{ runner.os }}-composer-${{ matrix.stability }}-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-progress --no-interaction
 
       - name: Run test suite
         run: vendor/bin/phpunit
 
   quality:
-    name: Run code quality
+    name: Code Quality
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.5"
+          tools: composer:v2
 
-      - name: Cache Composer packages
-        uses: actions/cache@v3
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer downloads
+        uses: actions/cache@v5
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-quality-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-
+            ${{ runner.os }}-composer-quality-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Run Mago Formatter Check
         run: vendor/bin/mago fmt --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
+    branches: ["*"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: "8.5"
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ "8.4", "8.5" ]
+        php: [ "8.5" ]
         stability: ["prefer-lowest", "prefer-stable"]
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: "8.5"
 
       - name: Cache Composer packages
         uses: actions/cache@v3

--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,17 @@
     "ext-json": "*",
     "tempest/framework": "^3.0"
   },
+  "conflict": {
+    "guzzlehttp/psr7": "<2.0",
+    "guzzlehttp/promises": "<2.0"
+  },
   "require-dev": {
     "ext-pdo_sqlite": "*",
     "carthage-software/mago": "1.8.0",
     "mockery/mockery": "^1.6.12",
     "phpunit/phpunit": "^12.5.11",
     "rector/rector": "2.3.6",
-    "illuminate/pagination": "^12.51.0"
+    "illuminate/pagination": "^13.0"
   },
   "suggest": {
     "illuminate/pagination": "Required to transform paginated data into a Laravel paginator instance.",

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
     ]
   },
   "require": {
-    "php": "^8.4",
+    "php": "^8.5",
     "ext-json": "*",
-    "tempest/framework": "^2.4"
+    "tempest/framework": "^3.0"
   },
   "require-dev": {
     "ext-pdo_sqlite": "*",

--- a/rector.php
+++ b/rector.php
@@ -13,6 +13,7 @@ use Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
+use Tempest\Upgrade\Set\TempestSetList;
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
@@ -22,9 +23,10 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
-    ->withPhpSets(php84: true)
+    ->withPhpSets(php85: true)
     ->withSets([
         PHPUnitSetList::PHPUNIT_120,
+        TempestSetList::TEMPEST_30,
     ])
     ->withRules([
         DeclareStrictTypesRector::class,

--- a/src/Exceptions/ComponentNotFoundException.php
+++ b/src/Exceptions/ComponentNotFoundException.php
@@ -6,9 +6,9 @@ namespace Inertia\Exceptions;
 
 use Exception;
 use Override;
-use Tempest\Core\HasContext;
+use Tempest\Core\ProvidesContext;
 
-final class ComponentNotFoundException extends Exception implements HasContext
+final class ComponentNotFoundException extends Exception implements ProvidesContext
 {
     public function __construct(
         private readonly string $component,

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -171,7 +171,7 @@ class Inertia extends Facade
     /**
      * @param BackedEnum|UnitEnum|string|array<string, mixed> $key
      */
-    public static function flash(array|BackedEnum|string|UnitEnum $key, mixed $value = null): \Inertia\ResponseFactory
+    public static function flash(array|BackedEnum|string|UnitEnum $key, mixed $value = null): ResponseFactory
     {
         return static::instance()
             ->flash(

--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -11,7 +11,6 @@ use Inertia\Response as InertiaResponse;
 use Inertia\ResponseFactory;
 use Inertia\Support\Header;
 use Inertia\Support\ResolveErrorProps;
-use Inertia\Support\SessionKey;
 use Override;
 use Tempest\Auth\Authentication\Authenticator;
 use Tempest\Core\Priority;
@@ -28,7 +27,7 @@ use Tempest\Vite\ViteConfig;
 
 use function Tempest\root_path;
 
-#[Priority(Priority::HIGH)]
+#[Priority(Priority::FRAMEWORK - 20)]
 class Middleware implements HttpMiddleware
 {
     public function __construct(
@@ -194,11 +193,7 @@ class Middleware implements HttpMiddleware
      */
     protected function reflash(): void
     {
-        $flashed = $this->inertia->getFlashed();
-
-        if ($flashed !== []) {
-            $this->session->flash(SessionKey::FlashData->value, $flashed);
-        }
+        $this->session->reflash();
     }
 
     /**

--- a/src/Props/ScrollProp.php
+++ b/src/Props/ScrollProp.php
@@ -16,7 +16,7 @@ use Inertia\Traits\ResolvesCallables;
 use Override;
 use Tempest\Http\Request;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 /**
  * Represents a paginated property that can be merged during partial reloads.

--- a/src/Response.php
+++ b/src/Response.php
@@ -39,8 +39,12 @@ use Tempest\Support\Arr\ArrayInterface;
 use Tempest\Support\Paginator\PaginatedData;
 use UnitEnum;
 
-use function Tempest\get;
-use function Tempest\invoke;
+use function Inertia\Support\Arr\forget_keys;
+use function Tempest\Container\get;
+use function Tempest\Container\invoke;
+use function Tempest\Support\Arr\get_by_key;
+use function Tempest\Support\Arr\set_by_key;
+use function Tempest\Support\Arr\to_array;
 
 final class Response implements HttpResponse
 {
@@ -207,7 +211,7 @@ final class Response implements HttpResponse
         foreach ($props as $key => $value) {
             if (is_numeric($key) && $value instanceof ProvidesInertiaProperties) {
                 /** @var array<string, mixed> $inertiaProps */
-                $inertiaProps = Arr\to_array($value->toInertiaProperties($renderContext));
+                $inertiaProps = to_array($value->toInertiaProperties($renderContext));
                 $newProps = array_merge($newProps, $inertiaProps);
                 continue;
             }
@@ -244,20 +248,20 @@ final class Response implements HttpResponse
             $newProps = [];
 
             foreach ($only as $key) {
-                $value = Arr\get_by_key($props, $key);
+                $value = get_by_key($props, $key);
 
                 if ($value instanceof ArrayInterface) {
                     $value = $value->toArray();
                 }
 
-                $newProps = Arr\set_by_key($newProps, $key, $value);
+                $newProps = set_by_key($newProps, $key, $value);
             }
 
             $props = $newProps;
         }
 
         if ($except !== []) {
-            Support\Arr\forget_keys($props, $except);
+            forget_keys($props, $except);
         }
 
         return $props;
@@ -360,7 +364,7 @@ final class Response implements HttpResponse
             }
 
             if ($unpackDotProps && is_string($key) && str_contains($key, '.')) {
-                $result = Arr\set_by_key($result, $key, $value);
+                $result = set_by_key($result, $key, $value);
             } else {
                 $result[$key] = $value;
             }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -31,8 +31,11 @@ use Tempest\Support\Arr;
 use Tempest\Support\Arr\ArrayInterface;
 use UnitEnum;
 
-use function Tempest\get;
-use function Tempest\invoke;
+use function Tempest\Container\get;
+use function Tempest\Container\invoke;
+use function Tempest\Support\Arr\get_by_key;
+use function Tempest\Support\Arr\merge;
+use function Tempest\Support\Arr\set_by_key;
 
 #[Singleton]
 final class ResponseFactory
@@ -108,11 +111,11 @@ final class ResponseFactory
         if (is_array($key)) {
             $this->sharedProps = array_merge($this->sharedProps, $key);
         } elseif ($key instanceof ArrayInterface) {
-            $this->sharedProps = Arr\merge($this->sharedProps, $key->toArray());
+            $this->sharedProps = merge($this->sharedProps, $key->toArray());
         } elseif ($key instanceof ProvidesInertiaProperties) {
             $this->sharedProps = array_merge($this->sharedProps, [$key]);
         } else {
-            $this->sharedProps = Arr\set_by_key($this->sharedProps, $key, $value);
+            $this->sharedProps = set_by_key($this->sharedProps, $key, $value);
         }
     }
 
@@ -124,7 +127,7 @@ final class ResponseFactory
     public function getShared(?string $key = null, mixed $default = null): mixed
     {
         if ($key) {
-            $value = Arr\get_by_key($this->sharedProps, $key, $default);
+            $value = get_by_key($this->sharedProps, $key, $default);
 
             if ($value instanceof ArrayInterface) {
                 return $value->toArray();

--- a/src/Ssr/BundleDetector.php
+++ b/src/Ssr/BundleDetector.php
@@ -6,7 +6,7 @@ namespace Inertia\Ssr;
 
 use Inertia\Configs\InertiaConfig;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 use function Tempest\root_path;
 
 final class BundleDetector

--- a/src/Ssr/Commands/StartSsr.php
+++ b/src/Ssr/Commands/StartSsr.php
@@ -11,8 +11,7 @@ use Symfony\Component\Process\Process;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\ExitCode;
 use Tempest\Console\HasConsole;
-
-use function Tempest\report;
+use Tempest\Core\Exceptions\ExceptionProcessor;
 
 final readonly class StartSsr
 {
@@ -22,6 +21,7 @@ final readonly class StartSsr
         private InertiaConfig $config,
         private BundleDetector $bundleDetector,
         private StopSsr $stopSsrCommand,
+        private ExceptionProcessor $exceptionProcessor,
     ) {}
 
     /**
@@ -83,7 +83,7 @@ final readonly class StartSsr
             }
 
             $this->console->error(trim($data));
-            report(new SsrException($data));
+            $this->exceptionProcessor->process(new SsrException($data));
         }
 
         return ExitCode::SUCCESS;

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -14,6 +14,8 @@ use Tempest\Router\Exceptions\MatchedRouteCouldNotBeResolved;
 use Tempest\Support\Str;
 use Throwable;
 
+use function Tempest\Support\Str\ensure_starts_with;
+
 final readonly class HttpGateway implements Gateway, HasHealthCheck
 {
     public function __construct(
@@ -95,6 +97,6 @@ final readonly class HttpGateway implements Gateway, HasHealthCheck
         $parts = parse_url($this->config->ssr->url);
         $baseUrl = "{$parts['scheme']}://{$parts['host']}:{$parts['port']}";
 
-        return $baseUrl . Str\ensure_starts_with($path, '/');
+        return $baseUrl . ensure_starts_with($path, '/');
     }
 }

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -11,7 +11,6 @@ use Inertia\Ssr\Contracts\HasHealthCheck;
 use Override;
 use Tempest\HttpClient\HttpClient;
 use Tempest\Router\Exceptions\MatchedRouteCouldNotBeResolved;
-use Tempest\Support\Str;
 use Throwable;
 
 use function Tempest\Support\Str\ensure_starts_with;

--- a/src/Support/Facade.php
+++ b/src/Support/Facade.php
@@ -6,7 +6,7 @@ namespace Inertia\Support;
 
 use RuntimeException;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 abstract class Facade
 {

--- a/src/Support/PaginatorAdapter.php
+++ b/src/Support/PaginatorAdapter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Inertia\Support;
 
+use Illuminate\Pagination\LengthAwarePaginator;
 use Inertia\Contracts\Arrayable;
 use Override;
 use RuntimeException;
@@ -17,9 +18,9 @@ final readonly class PaginatorAdapter implements Arrayable
         private Request $request,
     ) {}
 
-    public function toIlluminatePaginator(): \Illuminate\Pagination\LengthAwarePaginator
+    public function toIlluminatePaginator(): LengthAwarePaginator
     {
-        $laravelPaginatorClass = \Illuminate\Pagination\LengthAwarePaginator::class;
+        $laravelPaginatorClass = LengthAwarePaginator::class;
 
         if (! class_exists($laravelPaginatorClass)) {
             throw new RuntimeException(

--- a/src/Support/ResolveErrorProps.php
+++ b/src/Support/ResolveErrorProps.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Inertia\Support;
 
 use Inertia\Configs\InertiaConfig;
-use Tempest\Http\Session\Session;
-use Tempest\Validation\Rule;
+use Tempest\Http\Session\FormSession;
+use Tempest\Validation\FailingRule;
 use Tempest\Validation\Validator;
 
 use function Tempest\Support\arr;
@@ -14,21 +14,21 @@ use function Tempest\Support\arr;
 final readonly class ResolveErrorProps
 {
     public function __construct(
-        private Session $session,
+        private FormSession $formSession,
         private Validator $validator,
         private InertiaConfig $config,
     ) {}
 
     public function __invoke(): array
     {
-        /** @var array<string, Rule[]> $validationErrors */
-        $validationErrors = $this->session->get(Session::VALIDATION_ERRORS) ?? [];
+        /** @var array<string, FailingRule[]> $validationErrors */
+        $validationErrors = $this->formSession->getErrors();
 
         return arr($validationErrors)->map(function (array $rules, string $key): string|array|null {
             $fieldName = $this->config->validation->localize_fields ? $key : null;
 
             $messages = arr($rules)->map(
-                fn (Rule $rule) => $this->validator->getErrorMessage($rule, $fieldName),
+                fn (FailingRule $rule) => $this->validator->getErrorMessage($rule, $fieldName),
             )->toArray();
 
             if ($this->config->validation->multiple_errors) {

--- a/src/Support/ScrollMetadata.php
+++ b/src/Support/ScrollMetadata.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Inertia\Support;
 
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Inertia\Contracts\Arrayable;
 use Inertia\Contracts\ProvidesScrollMetadata;
 use InvalidArgumentException;
@@ -35,8 +37,8 @@ final readonly class ScrollMetadata implements Arrayable, ProvidesScrollMetadata
             );
         }
 
-        $paginatorClass = \Illuminate\Pagination\Paginator::class;
-        $lengthAwarePaginatorClass = \Illuminate\Pagination\LengthAwarePaginator::class;
+        $paginatorClass = Paginator::class;
+        $lengthAwarePaginatorClass = LengthAwarePaginator::class;
 
         if (
             class_exists($paginatorClass)

--- a/src/Traits/ResolvesCallables.php
+++ b/src/Traits/ResolvesCallables.php
@@ -6,7 +6,7 @@ namespace Inertia\Traits;
 
 use Closure;
 
-use function Tempest\invoke;
+use function Tempest\Container\invoke;
 
 trait ResolvesCallables
 {

--- a/src/Views/InertiaView.php
+++ b/src/Views/InertiaView.php
@@ -10,7 +10,7 @@ use Tempest\Support\Html\HtmlString;
 use Tempest\View\IsView;
 use Tempest\View\View;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 final class InertiaView implements View
 {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,7 +6,7 @@ use Inertia\Response;
 use Inertia\ResponseFactory;
 use Tempest\Support\Arr\ArrayInterface;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 if (! function_exists('inertia')) {
     function inertia(?string $component = null, array|ArrayInterface $props = []): Response|ResponseFactory

--- a/tests/Fixtures/FakeClientResponse.php
+++ b/tests/Fixtures/FakeClientResponse.php
@@ -12,6 +12,7 @@ use Tempest\Http\Header;
 use Tempest\Http\Response;
 use Tempest\Http\Status;
 use Tempest\View\View;
+use UnitEnum;
 
 final class FakeClientResponse implements Response
 {
@@ -61,19 +62,13 @@ final class FakeClientResponse implements Response
     }
 
     #[Override]
-    public function flash(string $key, mixed $value): self
+    public function flash(string|UnitEnum $key, mixed $value): self
     {
         return $this;
     }
 
     #[Override]
     public function removeSession(string $name): self
-    {
-        return $this;
-    }
-
-    #[Override]
-    public function destroySession(): self
     {
         return $this;
     }

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -15,10 +15,13 @@ use LogicException;
 use PHPUnit\Framework\Attributes\Test;
 use Tempest\Http\ContentType;
 use Tempest\Http\Request;
-use Tempest\Http\Session\Session;
+use Tempest\Http\Session\FormSession;
 use Tempest\Http\Status;
 use Tempest\Router\Exceptions\ControllerActionHadNoReturn;
-use Tempest\Validation\Rules;
+use Tempest\Validation\FailingRule;
+use Tempest\Validation\Rules\HasLength;
+use Tempest\Validation\Rules\IsEmail;
+use Tempest\Validation\Rules\IsNotEmptyString;
 
 use function Tempest\root_path;
 use function Tempest\Router\uri;
@@ -45,29 +48,29 @@ final class MiddlewareTest extends TestCase
     #[Test]
     public function no_response_value_can_be_customized_by_overriding_the_middleware_method(): void
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('An empty Inertia response was returned.');
-
-        $this->http->get(
+        $response = $this->http->get(
             uri: uri([TestController::class, 'customEmptyResponseAction']),
             headers: [
                 Header::INERTIA => 'true',
                 'Content-Type' => 'application/json',
             ],
         );
+
+        $this->assertInstanceOf(LogicException::class, $response->throwable);
+        $this->assertSame('An empty Inertia response was returned.', $response->throwable->getMessage());
     }
 
     #[Test]
     public function no_response_means_no_response_for_non_inertia_requests(): void
     {
-        $this->expectException(ControllerActionHadNoReturn::class);
-
-        $this->http->put(
+        $response = $this->http->put(
             uri: uri([TestController::class, 'voidPutAction']),
             headers: [
                 'Content-Type' => 'application/json',
             ],
         );
+
+        $this->assertInstanceOf(ControllerActionHadNoReturn::class, $response->throwable);
     }
 
     #[Test]
@@ -196,12 +199,11 @@ final class MiddlewareTest extends TestCase
             )),
         );
 
-        $session = $this->container->get(Session::class);
+        $formSession = $this->container->get(FormSession::class);
 
-        $validationErrors = [
-            'email' => [new rules\IsEmail(), new Rules\HasLength(min: 50)],
-        ];
-        $session->set(Session::VALIDATION_ERRORS, $validationErrors);
+        $formSession->setErrors([
+            'email' => [new FailingRule(new IsEmail()), new FailingRule(new HasLength(min: 50))],
+        ]);
 
         $middleware = $this->container->get(Middleware::class);
         $request = $this->container->get(Request::class);
@@ -223,13 +225,12 @@ final class MiddlewareTest extends TestCase
             )),
         );
 
-        $session = $this->container->get(Session::class);
+        $formSession = $this->container->get(FormSession::class);
 
-        $validationErrors = [
-            'email' => [new Rules\IsEmail(), new Rules\HasLength(min: 50)],
-            'name' => [new Rules\HasLength(min: 50)],
-        ];
-        $session->set(Session::VALIDATION_ERRORS, $validationErrors);
+        $formSession->setErrors([
+            'email' => [new FailingRule(new IsEmail()), new FailingRule(new HasLength(min: 50))],
+            'name' => [new FailingRule(new HasLength(min: 50))],
+        ]);
 
         $middleware = $this->container->get(Middleware::class);
         $request = $this->container->get(Request::class);
@@ -264,11 +265,11 @@ final class MiddlewareTest extends TestCase
             )),
         );
 
-        $session = $this->container->get(Session::class);
-        $validationErrors = [
-            'email' => [new Rules\IsNotEmptyString()],
-        ];
-        $session->set(Session::VALIDATION_ERRORS, $validationErrors);
+        $formSession = $this->container->get(FormSession::class);
+
+        $formSession->setErrors([
+            'email' => [new FailingRule(new IsNotEmptyString())],
+        ]);
 
         $middleware = $this->container->get(Middleware::class);
         $request = $this->container->get(Request::class);
@@ -291,11 +292,11 @@ final class MiddlewareTest extends TestCase
             )),
         );
 
-        $session = $this->container->get(Session::class);
-        $validationErrors = [
-            'email' => [new Rules\IsNotEmptyString()],
-        ];
-        $session->set(Session::VALIDATION_ERRORS, $validationErrors);
+        $formSession = $this->container->get(FormSession::class);
+
+        $formSession->setErrors([
+            'email' => [new FailingRule(new IsNotEmptyString())],
+        ]);
 
         $middleware = $this->container->get(Middleware::class);
         $request = $this->container->get(Request::class);
@@ -311,8 +312,8 @@ final class MiddlewareTest extends TestCase
     #[Test]
     public function default_validation_errors_can_be_overwritten(): void
     {
-        $session = $this->container->get(Session::class);
-        $session->set(Session::VALIDATION_ERRORS, ['name' => ['This should be overwritten.']]);
+        $formSession = $this->container->get(FormSession::class);
+        $formSession->setErrors(['name' => [new FailingRule(new IsNotEmptyString())]]);
 
         $response = $this->http->get(
             uri: uri([TestController::class, 'overwriteErrorsProp']),

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -18,7 +18,6 @@ use Inertia\Props\ScrollProp;
 use Inertia\Response;
 use Inertia\Support\Header;
 use Inertia\Support\RenderContext;
-use Inertia\Tests\Fixtures\CreateUserTable;
 use Inertia\Tests\Fixtures\FakeResource;
 use Inertia\Tests\Fixtures\TestController;
 use Inertia\Tests\Fixtures\User;
@@ -53,12 +52,6 @@ final class ResponseTest extends TestCase
 
             self::$dbInitialized = true;
         }
-    }
-
-    #[Override]
-    protected function migrateDatabase(): void
-    {
-        $this->database->migrate(CreateUserTable::class);
     }
 
     #[Test]
@@ -1093,7 +1086,7 @@ final class ResponseTest extends TestCase
         );
 
         $deferProp = new DeferProp(static fn (): Arrayable => new class implements Arrayable {
-            #[\Override]
+            #[Override]
             public function toArray(): array
             {
                 return ['foo' => 'bar'];

--- a/tests/Integration/ScrollPropTest.php
+++ b/tests/Integration/ScrollPropTest.php
@@ -7,7 +7,6 @@ namespace Inertia\Tests\Integration;
 use Inertia\Contracts\ProvidesScrollMetadata;
 use Inertia\Props\ScrollProp;
 use Inertia\Support\Header;
-use Inertia\Tests\Fixtures\CreateUserTable;
 use Inertia\Tests\Fixtures\User;
 use Inertia\Tests\Fixtures\UserSeeder;
 use Inertia\Tests\TestCase;
@@ -33,12 +32,6 @@ final class ScrollPropTest extends TestCase
         }
 
         $this->users = User::select()->paginate(15);
-    }
-
-    #[\Override]
-    protected function migrateDatabase(): void
-    {
-        $this->database->migrate(CreateUserTable::class);
     }
 
     #[Test]


### PR DESCRIPTION
Adding support for tempest 3.x

Now, I did some rough testing a coupe of days ago but you probably know more about underlying problems or issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Minimum PHP requirement raised to 8.5; CI updated and tooling refreshed
  * Framework dependency upgraded to Tempest 3.0; dependency constraints tightened

* **Improvements**
  * More reliable validation/error reporting and session flash handling
  * Improved server-side rendering error processing and URL handling
  * Pagination and scroll behavior consistency refinements

* **Tests**
  * Test suites updated to reflect new error/session flows and removed per-test migrations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->