### PR TITLE
refactor(middleware): update Priority namespace import

### DIFF
--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -12,7 +12,6 @@ use Inertia\Support\Header;
 use Inertia\Support\ResolveErrorProps;
 use Override;
 use Tempest\Auth\Authentication\Authenticator;
-use Tempest\Core\Priority;
 use Tempest\Http\GenericResponse;
 use Tempest\Http\Method;
 use Tempest\Http\Request;
@@ -23,6 +22,7 @@ use Tempest\Http\Status;
 use Tempest\Router\Exceptions\ControllerActionHadNoReturn;
 use Tempest\Router\HttpMiddleware;
 use Tempest\Router\HttpMiddlewareCallable;
+use Tempest\Support\Priority;
 use Tempest\Vite\ViteConfig;
 
 use function Tempest\root_path;


### PR DESCRIPTION
Hello,

Tempest v3.10.0 moved #[Priority] from Tempest\Core to Tempest\Support as a breaking change ([#2116](https://github.com/tempestphp/tempest-framework/pull/2116)), which breaks the middleware on newer versions.

This PR just updates the import in `Middleware.php` to point to the new namespace.