### PR TITLE
feat: add Tempest DateTimeInterface support and optimize Duration/int handling in until()

### DIFF
--- a/src/Traits/ResolvesOnce.php
+++ b/src/Traits/ResolvesOnce.php
@@ -40,7 +40,7 @@ trait ResolvesOnce
     public function once(
         bool $value = true,
         BackedEnum|UnitEnum|null|string $as = null,
-        Duration|int|null $until = null,
+        DateTimeInterface|\Tempest\DateTime\DateTimeInterface|DateInterval|Duration|int|null $until = null,
     ): static {
         $clone = clone($this, [
             'once' => $value,

--- a/src/Traits/ResolvesOnce.php
+++ b/src/Traits/ResolvesOnce.php
@@ -117,7 +117,7 @@ trait ResolvesOnce
             $delay instanceof Duration => (int) (
                 DateTime::now()->getTimestamp()->getMilliseconds() + $delay->getTotalMilliseconds()
             ),
-            default => DateTime::now()->getTimestamp()->getMilliseconds() + ($delay * 1000),
+            default => DateTime::now()->plusSeconds($delay)->getTimestamp()->getMilliseconds(),
         };
 
         return clone($this, ['expiresAt' => $milliseconds]);

--- a/src/Traits/ResolvesOnce.php
+++ b/src/Traits/ResolvesOnce.php
@@ -108,13 +108,16 @@ trait ResolvesOnce
     /**
      * Set the expiration for the once prop.
      */
-    public function until(DateTimeInterface|DateInterval|Duration|int $delay): static
+    public function until(DateTimeInterface|\Tempest\DateTime\DateTimeInterface|DateInterval|Duration|int $delay): static
     {
         $milliseconds = match (true) {
+            $delay instanceof \Tempest\DateTime\DateTimeInterface => $delay->getTimestamp()->getMilliseconds(),
             $delay instanceof DateTimeInterface => (int) DateTimeImmutable::createFromInterface($delay)->format('Uv'),
             $delay instanceof DateInterval => (int) new DateTimeImmutable()->add($delay)->format('Uv'),
-            $delay instanceof Duration => DateTime::now()->plus($delay)->getTimestamp()->getMilliseconds(),
-            default => DateTime::now()->plusSeconds($delay)->getTimestamp()->getMilliseconds(),
+            $delay instanceof Duration => (int) (
+                DateTime::now()->getTimestamp()->getMilliseconds() + $delay->getTotalMilliseconds()
+            ),
+            default => DateTime::now()->getTimestamp()->getMilliseconds() + ($delay * 1000),
         };
 
         return clone($this, ['expiresAt' => $milliseconds]);

--- a/src/Traits/ResolvesOnce.php
+++ b/src/Traits/ResolvesOnce.php
@@ -114,9 +114,7 @@ trait ResolvesOnce
             $delay instanceof \Tempest\DateTime\DateTimeInterface => $delay->getTimestamp()->getMilliseconds(),
             $delay instanceof DateTimeInterface => (int) DateTimeImmutable::createFromInterface($delay)->format('Uv'),
             $delay instanceof DateInterval => (int) new DateTimeImmutable()->add($delay)->format('Uv'),
-            $delay instanceof Duration => (int) (
-                DateTime::now()->getTimestamp()->getMilliseconds() + $delay->getTotalMilliseconds()
-            ),
+            $delay instanceof Duration => DateTime::now()->plus($delay)->getTimestamp()->getMilliseconds(),
             default => DateTime::now()->plusSeconds($delay)->getTimestamp()->getMilliseconds(),
         };
 

--- a/tests/Unit/OncePropTest.php
+++ b/tests/Unit/OncePropTest.php
@@ -11,6 +11,8 @@ use Inertia\Tests\Fixtures\BackedEnum;
 use Inertia\Tests\Fixtures\UnitEnum;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Tempest\DateTime\DateTime;
+use Tempest\DateTime\Duration;
 
 final class OncePropTest extends TestCase
 {
@@ -63,10 +65,35 @@ final class OncePropTest extends TestCase
     }
 
     #[Test]
+    public function can_expire_with_tempest_date_time_interface(): void
+    {
+        $onceProp = new OnceProp(static fn () => 'value');
+        $expiry = DateTime::now()->plusHours(1);
+
+        $this->assertSame($expiry->getTimestamp()->getMilliseconds(), $onceProp->until($expiry)->expiresAt());
+    }
+
+    #[Test]
     public function can_expire_with_date_interval(): void
     {
         $onceProp = new OnceProp(static fn () => 'value');
 
-        $this->assertNotNull($onceProp->until(new DateInterval('PT1H'))->expiresAt());
+        $this->assertGreaterThan(time() * 1000, $onceProp->until(new DateInterval('PT1H'))->expiresAt());
+    }
+
+    #[Test]
+    public function can_expire_with_duration(): void
+    {
+        $onceProp = new OnceProp(static fn () => 'value');
+
+        $this->assertGreaterThan(time() * 1000, $onceProp->until(Duration::hours(1))->expiresAt());
+    }
+
+    #[Test]
+    public function can_expire_with_seconds(): void
+    {
+        $onceProp = new OnceProp(static fn () => 'value');
+
+        $this->assertGreaterThan(time() * 1000, $onceProp->until(3600)->expiresAt());
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the `until()` method to accept additional datetime and duration types, including Tempest's native DateTime interface and raw seconds, providing greater flexibility in specifying expiration times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maarten-Dekker/inertia-tempest/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->