### PR TITLE
feat: add rescue option to deferred props

### DIFF
--- a/src/Contracts/Rescuable.php
+++ b/src/Contracts/Rescuable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inertia\Contracts;
+
+interface Rescuable
+{
+    /**
+     * Determine if resolution errors should be rescued.
+     */
+    public function shouldRescue(): bool;
+}

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -119,12 +119,13 @@ class Inertia extends Facade
         return static::instance()->optional($callback);
     }
 
-    public static function defer(callable $callback, string $group = 'default'): DeferProp
+    public static function defer(callable $callback, string $group = 'default', bool $rescue = false): DeferProp
     {
         return static::instance()
             ->defer(
                 callback: $callback,
                 group: $group,
+                rescue: $rescue,
             );
     }
 

--- a/src/Props/DeferProp.php
+++ b/src/Props/DeferProp.php
@@ -9,13 +9,14 @@ use Inertia\Contracts\IgnoreFirstLoad;
 use Inertia\Contracts\InvokableProp;
 use Inertia\Contracts\Mergeable;
 use Inertia\Contracts\Onceable;
+use Inertia\Contracts\Rescuable;
 use Inertia\Traits\DefersProps;
 use Inertia\Traits\MergesProps;
 use Inertia\Traits\ResolvesCallables;
 use Inertia\Traits\ResolvesOnce;
 use Override;
 
-final class DeferProp implements Deferrable, IgnoreFirstLoad, Mergeable, Onceable, InvokableProp
+final class DeferProp implements Deferrable, IgnoreFirstLoad, Mergeable, Onceable, Rescuable, InvokableProp
 {
     use DefersProps;
     use MergesProps;
@@ -32,8 +33,11 @@ final class DeferProp implements Deferrable, IgnoreFirstLoad, Mergeable, Onceabl
      * from the initial page load and only evaluated when requested by the
      * frontend, improving initial page performance.
      */
-    public function __construct(callable $callback, string $group = 'default')
-    {
+    public function __construct(
+        callable $callback,
+        string $group = 'default',
+        private bool $rescue = false,
+    ) {
         $this->callback = $callback;
         $this->defer($group);
     }
@@ -45,5 +49,14 @@ final class DeferProp implements Deferrable, IgnoreFirstLoad, Mergeable, Onceabl
     public function __invoke(): mixed
     {
         return $this->resolveCallable($this->callback);
+    }
+
+    /**
+     * Determine if resolution errors should be rescued.
+     */
+    #[Override]
+    public function shouldRescue(): bool
+    {
+        return $this->rescue;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -17,6 +17,7 @@ use Inertia\Contracts\Mergeable;
 use Inertia\Contracts\Onceable;
 use Inertia\Contracts\ProvidesInertiaProperties;
 use Inertia\Contracts\ProvidesInertiaProperty;
+use Inertia\Contracts\Rescuable;
 use Inertia\Props\AlwaysProp;
 use Inertia\Props\ScrollProp;
 use Inertia\Ssr\Contracts\Gateway;
@@ -35,6 +36,7 @@ use Tempest\Http\Response as HttpResponse;
 use Tempest\Support\Arr\ArrayInterface;
 use Tempest\Support\Paginator\PaginatedData;
 use Tempest\View\View;
+use Throwable;
 use UnitEnum;
 
 use function Inertia\Support\Arr\forget_keys;
@@ -59,6 +61,13 @@ final class Response implements HttpResponse
      * @var array<string, mixed>
      */
     private array $viewData = [];
+
+    /**
+     * The rescued properties that were omitted during resolution due to errors.
+     *
+     * @var array<int, string>
+     */
+    private array $rescuedProps = [];
 
     private Request $request {
         get => $this->request ??= get(Request::class);
@@ -311,51 +320,61 @@ final class Response implements HttpResponse
         $result = [];
 
         foreach ($props as $key => $value) {
-            if ($value instanceof ScrollProp) {
-                $value->configureMergeIntent();
-            }
-
-            $value = match (true) {
-                $value instanceof Closure => invoke($value),
-                $value instanceof InvokableProp => $value(),
-                default => $value,
-            };
-
-            if ($this->config->laravel_pagination && $value instanceof PaginatedData) {
-                $value = new PaginatorAdapter(
-                    paginator: $value,
-                    request: $this->request,
-                );
-            }
-
             $currentKey = $parentKey ? $parentKey . '.' . $key : $key;
 
-            if ($value instanceof ProvidesInertiaProperty) {
-                $value = $value->toInertiaProperty(new PropertyContext(
-                    key: $currentKey,
-                    props: $props,
-                ));
-            }
+            $shouldRescue = $value instanceof Rescuable && $value->shouldRescue();
 
-            $value = match (true) {
-                $value instanceof Arrayable, $value instanceof ArrayInterface => $value->toArray(),
-                $value instanceof PromiseInterface => $value->wait(),
-                $value instanceof HttpResponse => $value->body,
-                default => $value,
-            };
+            try {
+                if ($value instanceof ScrollProp) {
+                    $value->configureMergeIntent();
+                }
 
-            if (is_array($value)) {
-                $value = $this->resolvePropertyInstances(
-                    props: $value,
-                    unpackDotProps: false,
-                    parentKey: $currentKey,
-                );
-            }
+                $value = match (true) {
+                    $value instanceof Closure => invoke($value),
+                    $value instanceof InvokableProp => $value(),
+                    default => $value,
+                };
 
-            if ($unpackDotProps && is_string($key) && str_contains($key, '.')) {
-                $result = set_by_key($result, $key, $value);
-            } else {
-                $result[$key] = $value;
+                if ($this->config->laravel_pagination && $value instanceof PaginatedData) {
+                    $value = new PaginatorAdapter(
+                        paginator: $value,
+                        request: $this->request,
+                    );
+                }
+
+                if ($value instanceof ProvidesInertiaProperty) {
+                    $value = $value->toInertiaProperty(new PropertyContext(
+                        key: $currentKey,
+                        props: $props,
+                    ));
+                }
+
+                $value = match (true) {
+                    $value instanceof Arrayable, $value instanceof ArrayInterface => $value->toArray(),
+                    $value instanceof PromiseInterface => $value->wait(),
+                    $value instanceof HttpResponse => $value->body,
+                    default => $value,
+                };
+
+                if (is_array($value)) {
+                    $value = $this->resolvePropertyInstances(
+                        props: $value,
+                        unpackDotProps: false,
+                        parentKey: $currentKey,
+                    );
+                }
+
+                if ($unpackDotProps && is_string($key) && str_contains($key, '.')) {
+                    $result = set_by_key($result, $key, $value);
+                } else {
+                    $result[$key] = $value;
+                }
+            } catch (Throwable $e) {
+                if (! $shouldRescue) {
+                    throw $e;
+                }
+
+                $this->rescuedProps[] = $currentKey;
             }
         }
 
@@ -573,6 +592,7 @@ final class Response implements HttpResponse
             $this->resolveScrollProps(),
             $this->resolveOncePropsMetadata(),
             $this->resolveFlashData(),
+            $this->resolveRescuedProps(),
         );
 
         $this->setBody($this->resolveHttpBody($page));
@@ -610,6 +630,16 @@ final class Response implements HttpResponse
         $flash = inertia()->getFlashed();
 
         return $flash !== [] ? ['flash' => $flash] : [];
+    }
+
+    /**
+     * Resolve rescued props.
+     *
+     * @return array<string, array<int, string>>
+     */
+    private function resolveRescuedProps(): array
+    {
+        return $this->rescuedProps !== [] ? ['rescuedProps' => $this->rescuedProps] : [];
     }
 
     /**

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -230,9 +230,13 @@ final class ResponseFactory
     /**
      * Create a deferred property.
      */
-    public function defer(callable $callback, string $group = 'default'): DeferProp
+    public function defer(callable $callback, string $group = 'default', bool $rescue = false): DeferProp
     {
-        return new DeferProp($callback, $group);
+        return new DeferProp(
+            callback: $callback,
+            group: $group,
+            rescue: $rescue,
+        );
     }
 
     /**

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Inertia\Configs\InertiaConfig;
 use Inertia\Contracts\Arrayable;
 use Inertia\Contracts\ProvidesInertiaProperties;
+use Inertia\Contracts\ProvidesInertiaProperty;
 use Inertia\Contracts\ProvidesScrollMetadata;
 use Inertia\Inertia;
 use Inertia\Props\AlwaysProp;
@@ -17,6 +18,7 @@ use Inertia\Props\OptionalProp;
 use Inertia\Props\ScrollProp;
 use Inertia\Response;
 use Inertia\Support\Header;
+use Inertia\Support\PropertyContext;
 use Inertia\Support\RenderContext;
 use Inertia\Tests\Fixtures\TestController;
 use Inertia\Tests\TestCase;
@@ -25,6 +27,7 @@ use Mockery;
 use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
 use Tempest\DateTime\DateTime;
 use Tempest\DateTime\Duration;
 use Tempest\Support\Paginator\Paginator;
@@ -67,6 +70,111 @@ final class ResponseTest extends TestCase
 
         $this->assertArrayNotHasKey('foo', $page['props']);
         $this->assertSame(['default' => ['foo']], $page['deferredProps']);
+    }
+
+    #[Test]
+    public function server_response_with_rescued_deferred_prop_on_partial_request(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'foo',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => new DeferProp(
+                    static fn () => throw new RuntimeException('Rescue this deferred prop'),
+                    rescue: true,
+                ),
+            ],
+        );
+
+        $page = $response->body;
+
+        $this->assertArrayNotHasKey('foo', $page['props']);
+        $this->assertSame(['foo'], $page['rescuedProps']);
+    }
+
+    #[Test]
+    public function server_response_with_rescued_deferred_prop_nested(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'auth.notifications',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'auth' => [
+                    'notifications' => new DeferProp(
+                        static fn () => throw new RuntimeException('Rescue nested prop'),
+                        rescue: true,
+                    ),
+                ],
+            ],
+        );
+
+        $page = $response->body;
+
+        $this->assertArrayNotHasKey('notifications', $page['props']['auth']);
+        $this->assertSame(['auth.notifications'], $page['rescuedProps']);
+    }
+
+    #[Test]
+    public function server_response_with_rescued_deferred_prop_when_provides_inertia_property_throws(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'stats',
+        ]);
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'stats' => new DeferProp(static fn () => new class implements ProvidesInertiaProperty {
+                    #[Override]
+                    public function toInertiaProperty(PropertyContext $prop): mixed
+                    {
+                        throw new RuntimeException('Failed to resolve stats');
+                    }
+                }, rescue: true),
+            ],
+        );
+
+        $page = $response->body;
+
+        $this->assertArrayNotHasKey('stats', $page['props']);
+        $this->assertSame(['stats'], $page['rescuedProps']);
+    }
+
+    #[Test]
+    public function server_response_throws_exception_when_deferred_prop_fails_without_rescue(): void
+    {
+        $this->makeRequest(headers: [
+            Header::INERTIA => 'true',
+            Header::PARTIAL_COMPONENT => 'User/Edit',
+            Header::PARTIAL_ONLY => 'foo',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Fail this deferred prop');
+
+        $response = new Response(
+            component: 'User/Edit',
+            props: [
+                'foo' => new DeferProp(
+                    static fn () => throw new RuntimeException('Fail this deferred prop'),
+                    rescue: false,
+                ),
+            ],
+        );
+
+        $response->body;
     }
 
     #[Test]

--- a/tests/Unit/DeferPropTest.php
+++ b/tests/Unit/DeferPropTest.php
@@ -17,4 +17,12 @@ final class DeferPropTest extends TestCase
 
         $this->assertSame('date', $deferProp());
     }
+
+    #[Test]
+    public function can_be_marked_as_rescuable(): void
+    {
+        $deferProp = new DeferProp(static fn () => 'value', rescue: true);
+
+        $this->assertTrue($deferProp->shouldRescue());
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional rescue capability for deferred properties, allowing graceful handling of resolution failures. Failed rescued props are now tracked separately without interrupting the response.

* **Tests**
  * Added comprehensive integration and unit tests for rescue behavior during partial requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maarten-Dekker/inertia-tempest/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->