### PR TITLE
fix: adjust middleware priority for Tempest `>=3.11.3` compatibility

### DIFF
--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -27,7 +27,7 @@ use Tempest\Vite\ViteConfig;
 
 use function Tempest\root_path;
 
-#[Priority(Priority::FRAMEWORK - 20)]
+#[Priority(Priority::FRAMEWORK - 35)]
 class Middleware implements HttpMiddleware
 {
     public function __construct(


### PR DESCRIPTION
Tempest `3.11.3` updated the framework's exception-handling lifecycle ([tempestphp/tempest-framework#2143](https://github.com/tempestphp/tempest-framework/pull/2143)), shifting HandleRouteExceptionMiddleware from `Priority::FRAMEWORK - 10` down to `Priority::FRAMEWORK - 30`.

Because our middleware was set to `Priority::FRAMEWORK - 20`, it was suddenly executing outside of Tempest's core routing exception handler.